### PR TITLE
Range nav

### DIFF
--- a/manifest-editor/index.html
+++ b/manifest-editor/index.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 <head>
   <meta charset="UTF-8">

--- a/manifest-editor/src/apps/ManifestEditor/index.tsx
+++ b/manifest-editor/src/apps/ManifestEditor/index.tsx
@@ -12,6 +12,8 @@ import { CanvasThumbnailForm } from "../../editors/ThumbnailProperties/CanvasThu
 import { ThumbnailPage } from "./components/ThumbnailPage";
 import { limitation } from "../../helpers/limitation";
 import { PanelError } from "../../shell/Layout/components/PanelError";
+import { CanvasList } from "../../navigation/CanvasList/CanvasList";
+import { RangeNavigation } from "../../navigation/RangeNavigation/RangeNavigation";
 
 export default { id: "manifest-editor", title: "Manifest editor", project: true };
 
@@ -39,6 +41,16 @@ export const leftPanels: LayoutPanel[] = [
     id: "outline-view",
     label: "Outline view",
     render: () => <OutlinePlaceholder />,
+  },
+  {
+    id: "canvas-list-view",
+    label: "Canvas list view",
+    render: () => <CanvasList />,
+  },
+  {
+    id: "canvas-range-view",
+    label: "Structure",
+    render: () => <RangeNavigation />,
   },
 ];
 

--- a/manifest-editor/src/apps/ManifestEditor/index.tsx
+++ b/manifest-editor/src/apps/ManifestEditor/index.tsx
@@ -15,6 +15,7 @@ import { PanelError } from "../../shell/Layout/components/PanelError";
 import { CanvasList } from "../../navigation/CanvasList/CanvasList";
 import { RangeNavigation } from "../../navigation/RangeNavigation/RangeNavigation";
 import { CanvasVerticalThumbnails } from "../../navigation/CanvasVerticalThumbnails/CanvasVerticalThumbnails";
+import { ManifestDescriptive } from "../../resource-editors/manifest/ManifestDescriptive";
 
 export default { id: "manifest-editor", title: "Manifest editor", project: true };
 

--- a/manifest-editor/src/apps/ManifestEditor/index.tsx
+++ b/manifest-editor/src/apps/ManifestEditor/index.tsx
@@ -14,6 +14,7 @@ import { limitation } from "../../helpers/limitation";
 import { PanelError } from "../../shell/Layout/components/PanelError";
 import { CanvasList } from "../../navigation/CanvasList/CanvasList";
 import { RangeNavigation } from "../../navigation/RangeNavigation/RangeNavigation";
+import { CanvasVerticalThumbnails } from "../../navigation/CanvasVerticalThumbnails/CanvasVerticalThumbnails";
 
 export default { id: "manifest-editor", title: "Manifest editor", project: true };
 
@@ -36,6 +37,11 @@ export const leftPanels: LayoutPanel[] = [
         />
       );
     },
+  },
+  {
+    id: "canvas-vertical-list",
+    label: "Canvases",
+    render: () => <CanvasVerticalThumbnails />,
   },
   {
     id: "outline-view",

--- a/manifest-editor/src/apps/ManifestEditor/index.tsx
+++ b/manifest-editor/src/apps/ManifestEditor/index.tsx
@@ -75,6 +75,14 @@ export const centerPanels: LayoutPanel[] = [
     icon: "",
     render: (state, { actions }, ctx) => (
       <GridView
+        canvasIds={state.canvasIds}
+        clearCanvases={
+          state.canvasIds
+            ? () => {
+                actions.centerPanel.change({ id: "thumbnail-grid", state: { canvasIds: undefined } });
+              }
+            : undefined
+        }
         handleChange={(canvasId, thumbnails) => {
           ctx.setState({ canvasId });
           actions.open("canvas-properties");

--- a/manifest-editor/src/apps/PasteLogger/index.tsx
+++ b/manifest-editor/src/apps/PasteLogger/index.tsx
@@ -1,0 +1,56 @@
+import { LayoutPanel } from "../../shell/Layout/Layout.types";
+import { Reference } from "@iiif/presentation-3";
+import { useEffect, useState } from "react";
+import { UniversalCopyTarget } from "../../shell/Universal/UniversalCopyPaste";
+import styled from "styled-components";
+import { useVault } from "react-iiif-vault";
+import { analyse } from "../../helpers/analyse";
+import { Spinner } from "../../madoc/components/icons/Spinner";
+
+export default { id: "copy-paste", title: "Copy and paste", dev: true };
+
+export const centerPanels: LayoutPanel[] = [
+  {
+    id: "test-paste-ref",
+    label: "Test paste reference",
+    render: () => <TestPasteReference />,
+  },
+];
+
+const DropTarget = styled.pre`
+  width: 600px;
+  min-height: 250px;
+  background: #ddd;
+  margin: auto auto 1em;
+`;
+
+function TestPasteReference() {
+  const [ref, setRef] = useState<Reference>();
+  const [link, setLink] = useState<string>();
+  const vault = useVault();
+  const [resp, setResp] = useState<any>();
+
+  return (
+    <div style={{ padding: 40, overflowY: "auto" }}>
+      <h1>Test paste reference</h1>
+      <UniversalCopyTarget
+        onPasteReference={setRef}
+        onDropReference={setRef}
+        onPasteLink={setLink}
+        onPasteAnalysis={setResp}
+        as={DropTarget}
+        style={{ width: 600, height: 250, background: "#f9f9f9" }}
+      >
+        {ref ? JSON.stringify(ref) : "- paste in reference to inspect -"}
+      </UniversalCopyTarget>
+      {ref ? <DropTarget>{JSON.stringify(vault.get(ref), null, 2)}</DropTarget> : null}
+      {link || resp ? (
+        <>
+          <h2>Links</h2>
+          {link ? <a href={link}>{link}</a> : null}
+          {!resp ? <Spinner /> : <pre>{JSON.stringify(resp, null, 2)}</pre>}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/manifest-editor/src/apps/ProjectManager/components/ProjectListing/ProjectListing.tsx
+++ b/manifest-editor/src/apps/ProjectManager/components/ProjectListing/ProjectListing.tsx
@@ -3,9 +3,7 @@ import { projectFromManifest } from "../../../../shell/ProjectContext/helpers/pr
 import { getManifestNomalized } from "../../../../helpers/getManifestNormalized";
 
 export function ProjectListing() {
-  const { allProjects, current, loadingStatus, actions } = useProjectContext();
-
-  console.log({ allProjects, current });
+  const { allProjects, current, loadingStatus, actions, canDelete } = useProjectContext();
 
   if (loadingStatus && loadingStatus.loading) {
     return <div>Loading...</div>;
@@ -21,7 +19,9 @@ export function ProjectListing() {
             <button disabled={current?.id === project.id} onClick={() => actions.switchProject(project.id)}>
               select
             </button>
-            <button onClick={() => actions.deleteProject(project.id)}>delete</button>
+            <button disabled={!canDelete} onClick={() => actions.deleteProject(project.id)}>
+              delete
+            </button>
           </li>
         );
       })}

--- a/manifest-editor/src/atoms/ViewSelector.tsx
+++ b/manifest-editor/src/atoms/ViewSelector.tsx
@@ -68,6 +68,7 @@ export const ViewSelector: React.FC = () => {
       >
         <GridIcon />
       </Button>
+      {/*
       <Button
         onClick={() => {
           actions.leftPanel.open({ id: "canvas-list-view" });
@@ -93,5 +94,6 @@ export const ViewSelector: React.FC = () => {
         <CopyIcon />
       </Button>
     </FlexContainerRow>
+    */}
   );
 };

--- a/manifest-editor/src/atoms/ViewSelector.tsx
+++ b/manifest-editor/src/atoms/ViewSelector.tsx
@@ -7,6 +7,8 @@ import { useLayoutActions, useLayoutState } from "../shell/Layout/Layout.context
 import { useEffect, useState } from "react";
 import { VerticalDivider } from "./VerticalDivider";
 import { PaddingComponentSmall } from "./PaddingComponent";
+import { MenuIcon } from "../icons/MenuIcon";
+import { ExperimentalIcon } from "../madoc/components/icons/ExperimentalIcon";
 
 export const ViewSelector: React.FC = () => {
   const actions = useLayoutActions();
@@ -63,6 +65,22 @@ export const ViewSelector: React.FC = () => {
         style={activeCenterPanelState === "thumbnail-grid" ? { background: "lightgrey" } : { background: "white" }}
       >
         <GridIcon />
+      </Button>
+      <Button
+        onClick={() => {
+          actions.leftPanel.open({id: "canvas-list-view" });
+        }}
+        title="Switch to canvas list"
+      >
+        <MenuIcon />
+      </Button>
+      <Button
+        onClick={() => {
+          actions.leftPanel.open({id: "canvas-range-view" });
+        }}
+        title="Switch to structure"
+      >
+        <ExperimentalIcon />
       </Button>
     </FlexContainerRow>
   );

--- a/manifest-editor/src/atoms/ViewSelector.tsx
+++ b/manifest-editor/src/atoms/ViewSelector.tsx
@@ -93,7 +93,7 @@ export const ViewSelector: React.FC = () => {
       >
         <CopyIcon />
       </Button>
+      */}
     </FlexContainerRow>
-    */}
   );
 };

--- a/manifest-editor/src/atoms/ViewSelector.tsx
+++ b/manifest-editor/src/atoms/ViewSelector.tsx
@@ -9,6 +9,8 @@ import { VerticalDivider } from "./VerticalDivider";
 import { PaddingComponentSmall } from "./PaddingComponent";
 import { MenuIcon } from "../icons/MenuIcon";
 import { ExperimentalIcon } from "../madoc/components/icons/ExperimentalIcon";
+import { BlockIcon } from "../icons/BlockIcon";
+import { CopyIcon } from "../icons/CopyIcon";
 
 export const ViewSelector: React.FC = () => {
   const actions = useLayoutActions();
@@ -68,7 +70,7 @@ export const ViewSelector: React.FC = () => {
       </Button>
       <Button
         onClick={() => {
-          actions.leftPanel.open({id: "canvas-list-view" });
+          actions.leftPanel.open({ id: "canvas-list-view" });
         }}
         title="Switch to canvas list"
       >
@@ -76,11 +78,19 @@ export const ViewSelector: React.FC = () => {
       </Button>
       <Button
         onClick={() => {
-          actions.leftPanel.open({id: "canvas-range-view" });
+          actions.leftPanel.open({ id: "canvas-range-view" });
         }}
         title="Switch to structure"
       >
         <ExperimentalIcon />
+      </Button>
+      <Button
+        onClick={() => {
+          actions.leftPanel.open({ id: "canvas-vertical-list" });
+        }}
+        title="Vertical list"
+      >
+        <CopyIcon />
       </Button>
     </FlexContainerRow>
   );

--- a/manifest-editor/src/components/modals/NewCanvasModal.tsx
+++ b/manifest-editor/src/components/modals/NewCanvasModal.tsx
@@ -20,6 +20,7 @@ import { v4 } from "uuid";
 import { useApps } from "../../shell/AppContext/AppContext";
 import { useProjectCreators } from "../../shell/ProjectContext/ProjectContext.hooks";
 import { createCanvasFromImage } from "../../iiif-builder-extensions/create-canvas-from-image";
+import { createCanvasFromImageService } from "../../iiif-builder-extensions/create-canvas-from-image-service";
 
 export const NewCanvasModal: React.FC<{
   close: any;
@@ -81,28 +82,8 @@ export const NewCanvasModal: React.FC<{
       }
     } else if (inputed && inputed.type === "ImageService" && !emptyCanvas && manifest) {
       const builder = new IIIFBuilder(vault);
-      builder.editManifest(manifest.id, (mani) => {
-        mani.createCanvas(newCanvasID, (can: any) => {
-          can.entity.id = newCanvasID;
-          can.height = inputed?.height;
-          can.width = inputed?.width;
-          can.createAnnotation(`${newCanvasID}/painting`, {
-            id: `${newCanvasID}/painting`,
-            type: "Annotation",
-            motivation: "painting",
-            body: [
-              {
-                id: inputValue,
-                type: "Image",
-                format: inputed?.format,
-                height: inputed?.height,
-                width: inputed?.width,
-                service: [inputed],
-              },
-            ],
-          });
-        });
-      });
+
+      createCanvasFromImageService(builder, manifest.id, inputed, { newCanvasId: newCanvasID });
 
       if (!addAnother) {
         close();

--- a/manifest-editor/src/components/modals/NewCanvasModal.tsx
+++ b/manifest-editor/src/components/modals/NewCanvasModal.tsx
@@ -19,6 +19,7 @@ import { Loading } from "../../atoms/Loading";
 import { v4 } from "uuid";
 import { useApps } from "../../shell/AppContext/AppContext";
 import { useProjectCreators } from "../../shell/ProjectContext/ProjectContext.hooks";
+import { createCanvasFromImage } from "../../iiif-builder-extensions/create-canvas-from-image";
 
 export const NewCanvasModal: React.FC<{
   close: any;
@@ -72,25 +73,8 @@ export const NewCanvasModal: React.FC<{
     setIsLoading(false);
     if (inputed && inputed.type === "Image" && !emptyCanvas && manifest) {
       const builder = new IIIFBuilder(vault);
-      builder.editManifest(manifest.id, (mani: any) => {
-        mani.createCanvas(newCanvasID, (can: any) => {
-          can.entity.id = newCanvasID;
-          can.height = inputed?.height;
-          can.width = inputed?.width;
-          can.createAnnotation(`${newCanvasID}/painting`, {
-            id: `${newCanvasID}/painting`,
-            type: "Annotation",
-            motivation: "painting",
-            body: {
-              id: inputValue,
-              type: "Image",
-              format: inputed?.format,
-              height: inputed?.height,
-              width: inputed?.width,
-            },
-          });
-        });
-      });
+
+      createCanvasFromImage(builder, manifest.id, inputed, { newCanvasId: newCanvasID });
 
       if (!addAnother) {
         close();

--- a/manifest-editor/src/components/organisms/EmptyCanvasState/EmptyCanvasState.tsx
+++ b/manifest-editor/src/components/organisms/EmptyCanvasState/EmptyCanvasState.tsx
@@ -1,26 +1,12 @@
 import { FloatingPanel, FloatingPanelContainer, FloatingPanelInner, TextOverlay } from "./EmptyCanvasState.styles";
 import { UniversalCopyTarget } from "../../../shell/Universal/UniversalCopyPaste";
-import { createCanvasFromImage } from "../../../iiif-builder-extensions/create-canvas-from-image";
-import { useResourceContext, useVault } from "react-iiif-vault";
-import { useMemo } from "react";
-import { IIIFBuilder } from "iiif-builder";
-import { useCanvasSubset } from "../../../hooks/useCanvasSubset";
-import { useManifestEditor } from "../../../apps/ManifestEditor/ManifestEditor.context";
+import { usePasteCanvas } from "../../../hooks/usePasteCanvas";
 
 export function EmptyCanvasState() {
-  const vault = useVault();
-  const builder = useMemo(() => new IIIFBuilder(vault), [vault]);
-  const ctx = useResourceContext();
+  const onPasteCanvas = usePasteCanvas();
 
   return (
-    <UniversalCopyTarget
-      style={{ flex: 1, background: "#fff" }}
-      onPasteAnalysis={(result) => {
-        if (ctx.manifest && result.type === "Image") {
-          createCanvasFromImage(builder, ctx.manifest, result);
-        }
-      }}
-    >
+    <UniversalCopyTarget style={{ flex: 1, background: "#fff" }} onPasteAnalysis={onPasteCanvas}>
       <div
         style={{
           overflow: "hidden",

--- a/manifest-editor/src/components/organisms/EmptyCanvasState/EmptyCanvasState.tsx
+++ b/manifest-editor/src/components/organisms/EmptyCanvasState/EmptyCanvasState.tsx
@@ -1,8 +1,26 @@
 import { FloatingPanel, FloatingPanelContainer, FloatingPanelInner, TextOverlay } from "./EmptyCanvasState.styles";
+import { UniversalCopyTarget } from "../../../shell/Universal/UniversalCopyPaste";
+import { createCanvasFromImage } from "../../../iiif-builder-extensions/create-canvas-from-image";
+import { useResourceContext, useVault } from "react-iiif-vault";
+import { useMemo } from "react";
+import { IIIFBuilder } from "iiif-builder";
+import { useCanvasSubset } from "../../../hooks/useCanvasSubset";
+import { useManifestEditor } from "../../../apps/ManifestEditor/ManifestEditor.context";
 
 export function EmptyCanvasState() {
+  const vault = useVault();
+  const builder = useMemo(() => new IIIFBuilder(vault), [vault]);
+  const ctx = useResourceContext();
+
   return (
-    <div style={{ flex: 1, background: "#fff" }}>
+    <UniversalCopyTarget
+      style={{ flex: 1, background: "#fff" }}
+      onPasteAnalysis={(result) => {
+        if (ctx.manifest && result.type === "Image") {
+          createCanvasFromImage(builder, ctx.manifest, result);
+        }
+      }}
+    >
       <div
         style={{
           overflow: "hidden",
@@ -72,6 +90,6 @@ export function EmptyCanvasState() {
           <h1>No canvases</h1>
         </TextOverlay>
       </div>
-    </div>
+    </UniversalCopyTarget>
   );
 }

--- a/manifest-editor/src/components/organisms/GridView/GridItem.tsx
+++ b/manifest-editor/src/components/organisms/GridView/GridItem.tsx
@@ -19,7 +19,7 @@ import { CanvasThumbnail } from "../CanvasThumbnail/CanvasThumbnail";
 export const GridItem: React.FC<{
   handleChange: (id: string, e: any) => void;
   canvasId: string;
-  reorder: (fromPosition: number, toPosition: number) => void;
+  reorder?: (fromPosition: number, toPosition: number) => void;
   remove: (fromPosition: number, ref: Reference) => void;
   index: number;
 }> = ({ handleChange, canvasId, reorder, remove, index }) => {
@@ -69,30 +69,34 @@ export const GridItem: React.FC<{
             New canvas
           </ModalButton>
           <HorizontalDivider />
-          <DropdownItem
-            onClick={() => {
-              reorder(index, 0);
-              setContextMenuVisible(false);
-            }}
-          >
-            Move to beginning
-          </DropdownItem>
-          <DropdownItem
-            onClick={() => {
-              if (
-                manifest &&
-                manifest[dispatchType] &&
-                Array.isArray(manifest[dispatchType]) &&
-                manifest[dispatchType]
-              ) {
-                reorder(index, manifest[dispatchType].length - 1);
-              }
-              setContextMenuVisible(false);
-            }}
-          >
-            Move to end
-          </DropdownItem>
-          <HorizontalDivider />
+          {reorder ? (
+            <>
+              <DropdownItem
+                onClick={() => {
+                  reorder(index, 0);
+                  setContextMenuVisible(false);
+                }}
+              >
+                Move to beginning
+              </DropdownItem>
+              <DropdownItem
+                onClick={() => {
+                  if (
+                    manifest &&
+                    manifest[dispatchType] &&
+                    Array.isArray(manifest[dispatchType]) &&
+                    manifest[dispatchType]
+                  ) {
+                    reorder(index, manifest[dispatchType].length - 1);
+                  }
+                  setContextMenuVisible(false);
+                }}
+              >
+                Move to end
+              </DropdownItem>
+              <HorizontalDivider />
+            </>
+          ) : null}
           <DropdownItem
             onClick={() => {
               remove(index, { id: canvasId, type: "Canvas" });

--- a/manifest-editor/src/components/organisms/GridView/GridList.tsx
+++ b/manifest-editor/src/components/organisms/GridView/GridList.tsx
@@ -80,9 +80,9 @@ export const GridList: React.FC<{
   }
   const Sortable = canvasIds
     ? {
-        List: Fragment,
-        Item: Fragment,
-        Knob: Fragment,
+        List: "div",
+        Item: "div",
+        Knob: "div",
       }
     : {
         List: SortableList,

--- a/manifest-editor/src/components/organisms/GridView/GridView.tsx
+++ b/manifest-editor/src/components/organisms/GridView/GridView.tsx
@@ -12,22 +12,24 @@ import { GridList } from "./GridList";
 import { HeightWidthSwitcher, ThumbnailSize } from "../../../atoms/HeightWidthSwitcher";
 import { ModalButton } from "../../../madoc/components/ModalButton";
 import { NewCanvas } from "../../widgets/NewCanvas";
-import { CalltoButton } from "../../../atoms/Button";
+import { Button, CalltoButton } from "../../../atoms/Button";
 import { PaddingComponentSmall } from "../../../atoms/PaddingComponent";
+import { useCanvasSubset } from "../../../hooks/useCanvasSubset";
+import { Reference } from "@iiif/presentation-3";
+import { InfoMessage } from "../../../madoc/components/callouts/InfoMessage";
 
 export const GridView: React.FC<{
   handleChange: (canvasId: string, thumbnail?: boolean) => void;
   width?: number;
   strip?: boolean;
   column?: boolean;
-}> = ({ handleChange, width, strip, column }) => {
-  const manifest = useManifest();
-
+  canvasIds?: Array<string | Reference>;
+  clearCanvases?: () => void;
+}> = ({ handleChange, width, strip, column, canvasIds, clearCanvases }) => {
+  const canvases = useCanvasSubset(canvasIds);
   const editorContext = useManifestEditor();
 
-  const dispatchType = "items";
-
-  if (!manifest || !manifest[dispatchType] || manifest[dispatchType].length <= 0) {
+  if (canvases.length === 0) {
     return (
       <GridViewContainer
         strip={strip}
@@ -54,43 +56,55 @@ export const GridView: React.FC<{
     );
   }
   return (
-    <GridViewContainer $column={strip}>
-      <GridList handleChange={handleChange} />
-      {!strip && (
-        <FlexContainerRow>
-          {/* <ViewSelector /> */}
-          <HeightWidthSwitcher
-            options={[
-              { h: 128, w: 128 },
-              { h: 256, w: 256 },
-              { h: 512, w: 512 },
-              { h: 1024, w: 1024 },
-            ]}
-            label={`${editorContext?.thumbnailSize?.w}x${editorContext?.thumbnailSize?.h}`}
-            onOptionClick={(selected: ThumbnailSize) => editorContext?.setThumbnailSize(selected)}
-          />
-        </FlexContainerRow>
-      )}
-      {strip && (
-        <>
-          <PaddingComponentSmall />
-          <ModalButton
-            as={CalltoButton}
-            render={({ close }) => (
-              <NewCanvas
-                close={() => {
-                  close();
-                }}
-              />
-            )}
-            title="New Canvas"
-          >
-            <AddIcon height={300} color={"white"} />
+    <>
+      {clearCanvases ? (
+        <InfoMessage>
+          You are viewing only a subset of the canvases on this manifest{" "}
+          <Button style={{ marginLeft: "1em" }} onClick={clearCanvases}>
+            Show all
+          </Button>
+        </InfoMessage>
+      ) : null}
+
+      <GridViewContainer $column={strip}>
+        <GridList handleChange={handleChange} canvasIds={canvasIds} />
+
+        {!strip && (
+          <FlexContainerRow>
+            {/* <ViewSelector /> */}
+            <HeightWidthSwitcher
+              options={[
+                { h: 128, w: 128 },
+                { h: 256, w: 256 },
+                { h: 512, w: 512 },
+                { h: 1024, w: 1024 },
+              ]}
+              label={`${editorContext?.thumbnailSize?.w}x${editorContext?.thumbnailSize?.h}`}
+              onOptionClick={(selected: ThumbnailSize) => editorContext?.setThumbnailSize(selected)}
+            />
+          </FlexContainerRow>
+        )}
+        {strip && (
+          <>
             <PaddingComponentSmall />
-            Add Canvas
-          </ModalButton>
-        </>
-      )}
-    </GridViewContainer>
+            <ModalButton
+              as={CalltoButton}
+              render={({ close }) => (
+                <NewCanvas
+                  close={() => {
+                    close();
+                  }}
+                />
+              )}
+              title="New Canvas"
+            >
+              <AddIcon height={300} color={"white"} />
+              <PaddingComponentSmall />
+              Add Canvas
+            </ModalButton>
+          </>
+        )}
+      </GridViewContainer>
+    </>
   );
 };

--- a/manifest-editor/src/components/organisms/GridView/GridView.tsx
+++ b/manifest-editor/src/components/organisms/GridView/GridView.tsx
@@ -1,12 +1,6 @@
-import { useManifest, useResourceContext, useVault } from "react-iiif-vault";
-
 import { useManifestEditor } from "../../../apps/ManifestEditor/ManifestEditor.context";
-
-import { ViewSelector } from "../../../atoms/ViewSelector";
 import { FlexContainer, FlexContainerRow } from "../../layout/FlexContainer";
-
 import { AddIcon } from "../../../icons/AddIcon";
-
 import { GridViewContainer } from "./GridView.styles";
 import { GridList } from "./GridList";
 import { HeightWidthSwitcher, ThumbnailSize } from "../../../atoms/HeightWidthSwitcher";
@@ -18,9 +12,7 @@ import { useCanvasSubset } from "../../../hooks/useCanvasSubset";
 import { Reference } from "@iiif/presentation-3";
 import { InfoMessage } from "../../../madoc/components/callouts/InfoMessage";
 import { UniversalCopyTarget } from "../../../shell/Universal/UniversalCopyPaste";
-import { IIIFBuilder } from "iiif-builder";
-import { useMemo } from "react";
-import { createCanvasFromImage } from "../../../iiif-builder-extensions/create-canvas-from-image";
+import { usePasteCanvas } from "../../../hooks/usePasteCanvas";
 
 export const GridView: React.FC<{
   handleChange: (canvasId: string, thumbnail?: boolean) => void;
@@ -30,11 +22,9 @@ export const GridView: React.FC<{
   canvasIds?: Array<string | Reference>;
   clearCanvases?: () => void;
 }> = ({ handleChange, width, strip, column, canvasIds, clearCanvases }) => {
-  const vault = useVault();
-  const builder = useMemo(() => new IIIFBuilder(vault), [vault]);
   const canvases = useCanvasSubset(canvasIds);
   const editorContext = useManifestEditor();
-  const ctx = useResourceContext();
+  const onPasteCanvas = usePasteCanvas();
 
   if (canvases.length === 0) {
     return (
@@ -44,11 +34,7 @@ export const GridView: React.FC<{
       >
         <UniversalCopyTarget
           as={FlexContainer}
-          onPasteAnalysis={(result) => {
-            if (ctx.manifest && result.type === "Image") {
-              createCanvasFromImage(builder, ctx.manifest, result);
-            }
-          }}
+          onPasteAnalysis={onPasteCanvas}
           style={{ justifyContent: "center", width: "100%" }}
         >
           <ModalButton
@@ -81,15 +67,7 @@ export const GridView: React.FC<{
         </InfoMessage>
       ) : null}
 
-      <UniversalCopyTarget
-        as={GridViewContainer}
-        onPasteAnalysis={(result) => {
-          if (ctx.manifest && result.type === "Image") {
-            createCanvasFromImage(builder, ctx.manifest, result);
-          }
-        }}
-        $column={strip}
-      >
+      <UniversalCopyTarget as={GridViewContainer} onPasteAnalysis={onPasteCanvas} $column={strip}>
         <GridList handleChange={handleChange} canvasIds={canvasIds} />
 
         {!strip && (

--- a/manifest-editor/src/components/organisms/ThumbnailPagedList/ThumbnailPageList.styles.ts
+++ b/manifest-editor/src/components/organisms/ThumbnailPagedList/ThumbnailPageList.styles.ts
@@ -36,14 +36,20 @@ export const ThumbnailPlaceholder = styled.div`
   background: ${greyBg2};
 `;
 
-export const ThumbnailImage = styled(LazyLoadImage)`
+export const ThumbnailImage = styled(LazyLoadImage)<{ $fluid?: boolean }>`
   display: block;
   max-width: 100%;
   user-drag: none;
   object-fit: contain;
   object-position: center;
-  width: 128px;
-  height: 128px;
+
+  ${(props) =>
+    props.$fluid
+      ? css``
+      : css`
+          width: 128px;
+          height: 128px;
+        `}
 `;
 
 export const ThumbnailViewer = styled.div`

--- a/manifest-editor/src/components/organisms/ThumbnailPagedList/ThumbnailPagedList.tsx
+++ b/manifest-editor/src/components/organisms/ThumbnailPagedList/ThumbnailPagedList.tsx
@@ -1,8 +1,8 @@
-import { CanvasContext, useManifest, useSimpleViewer, useVault, VisibleCanvasReactContext } from 'react-iiif-vault';
-import { SingleCanvasThumbnail } from '../SingleCanvasThumbnail/SingleCanvasThumbnail';
-import { ThumbnailViewer, Thumbnail, ThumbnailCover } from './ThumbnailPageList.styles';
-import { useContext, useLayoutEffect } from 'react';
-import { CanvasNormalized } from '@iiif/presentation-3';
+import { CanvasContext, useManifest, useSimpleViewer, useVault, VisibleCanvasReactContext } from "react-iiif-vault";
+import { SingleCanvasThumbnail } from "../SingleCanvasThumbnail/SingleCanvasThumbnail";
+import { ThumbnailViewer, Thumbnail, ThumbnailCover } from "./ThumbnailPageList.styles";
+import { useContext, useLayoutEffect } from "react";
+import { CanvasNormalized } from "@iiif/presentation-3";
 
 export function ThumbnailPagedList() {
   const manifest = useManifest();
@@ -14,8 +14,8 @@ export function ThumbnailPagedList() {
     const found = document.querySelector(`[data-canvas-thumbnail-index="${currentCanvasIndex}"]`);
     if (found) {
       found.scrollIntoView({
-        block: 'nearest',
-        behavior: 'auto',
+        block: "nearest",
+        behavior: "auto",
       });
     }
   }, [currentCanvasIndex]);
@@ -25,7 +25,7 @@ export function ThumbnailPagedList() {
       {manifest.items.map((canvasRef, idx) => {
         const canvas = vault.get<CanvasNormalized>(canvasRef);
 
-        const T = canvas.behavior.indexOf('non-paged') !== -1 || idx === 0 ? ThumbnailCover : Thumbnail;
+        const T = canvas.behavior.indexOf("non-paged") !== -1 || idx === 0 ? ThumbnailCover : Thumbnail;
 
         return (
           <CanvasContext key={canvas.id} canvas={canvas.id}>

--- a/manifest-editor/src/editors/CanvasProperties/TechnicalForm.tsx
+++ b/manifest-editor/src/editors/CanvasProperties/TechnicalForm.tsx
@@ -1,9 +1,16 @@
 import { DimensionsForm } from "./DimensionsForm";
 import { SingleValueInput } from "./SingleValueInput";
+import { Input, InputContainer, InputLabel } from "../Input";
+import { useCanvas } from "react-iiif-vault";
 
 export const TechnicalForm = () => {
+  const canvas = useCanvas();
   return (
     <>
+      <InputContainer wide>
+        <InputLabel>Identifier</InputLabel>
+        <Input disabled value={canvas?.id} />
+      </InputContainer>
       <SingleValueInput dispatchType={"behavior"} />
       <DimensionsForm />
     </>

--- a/manifest-editor/src/editors/generic/LanguageFieldEditor/LanguageFieldEditor.styles.ts
+++ b/manifest-editor/src/editors/generic/LanguageFieldEditor/LanguageFieldEditor.styles.ts
@@ -32,7 +32,8 @@ export const EmptyLanguageField = styled(ButtonReset)`
   color: #999;
   font-size: 0.8em;
   border-bottom: 1px solid rgba(5, 42, 68, 0.2);
-  width: 100%;
-  display: flex;
-  margin-bottom: 1rem;
+  margin: 0.35em 0.5em 1rem;
+  width: calc(100% - 1em);
+  display: block;
+  text-align: left;
 `;

--- a/manifest-editor/src/editors/generic/LanguageFieldEditor/LanguageFieldEditor.tsx
+++ b/manifest-editor/src/editors/generic/LanguageFieldEditor/LanguageFieldEditor.tsx
@@ -1,10 +1,9 @@
-import React, { ChangeEvent, useEffect, useMemo, useReducer, useRef, useState } from "react";
+import React, { ChangeEvent, useMemo, useState } from "react";
 import { useMetadataEditor, UseMetadataEditor } from "../../../hooks/useMetadataEditor";
 import { SmallButton } from "../../../atoms/Button";
-import { EmptyProperty } from "../../../atoms/EmptyProperty";
 import { InformationLink } from "../../../atoms/InformationLink";
 import { CloseIcon } from "../../../icons/CloseIcon";
-import { FlexContainer, FlexContainerColumn } from "../../../components/layout/FlexContainer";
+import { FlexContainer } from "../../../components/layout/FlexContainer";
 import { InputGroup, InputUnderlined } from "../../Input";
 import { DropdownItem, StyledSelect } from "../../LanguageSelector";
 import { useDebounce } from "tiny-use-debounce";
@@ -12,7 +11,7 @@ import { AddAnother, FormFieldWrapper, Label, EmptyLanguageField } from "./Langu
 import { useDecayState } from "../../../hooks/useDecayState";
 import { flushSync } from "react-dom";
 import Textarea from "react-textarea-autosize";
-import { PaddingComponentMedium, PaddingComponentSmall } from "../../../atoms/PaddingComponent";
+import { PaddingComponentMedium } from "../../../atoms/PaddingComponent";
 
 export interface LanguageFieldEditorProps extends UseMetadataEditor {
   label: string;

--- a/manifest-editor/src/editors/generic/LanguageMapEditor/LanguageMapEditor.tsx
+++ b/manifest-editor/src/editors/generic/LanguageMapEditor/LanguageMapEditor.tsx
@@ -11,7 +11,7 @@ import { useConfig } from "../../../shell/ConfigContext/ConfigContext";
 
 export const supported: LanguageMapEditorProps["dispatchType"][] = ["label", "summary"];
 
-export function LanguageMapEditor({ dispatchType, languages, guidanceReference }: LanguageMapEditorProps) {
+export function LanguageMapEditor({ dispatchType, languages, guidanceReference, disableMultiline }: LanguageMapEditorProps) {
   const resource = useResource<Partial<DescriptiveProperties>>();
   const vault = useVault();
   const { defaultLanguages } = useConfig();
@@ -37,6 +37,7 @@ export function LanguageMapEditor({ dispatchType, languages, guidanceReference }
             onSave={changeHandler}
             availableLanguages={languages || defaultLanguages}
             guidanceReference={guidanceReference}
+            disableMultiline={disableMultiline}
           />
         </ErrorBoundary>
       )}

--- a/manifest-editor/src/editors/generic/LanguageMapEditor/LanguageMapEditor.types.ts
+++ b/manifest-editor/src/editors/generic/LanguageMapEditor/LanguageMapEditor.types.ts
@@ -2,4 +2,5 @@ export interface LanguageMapEditorProps {
   dispatchType: "label" | "summary";
   languages?: Array<string>;
   guidanceReference?: string;
+  disableMultiline?: boolean;
 }

--- a/manifest-editor/src/helpers/analyse.ts
+++ b/manifest-editor/src/helpers/analyse.ts
@@ -68,7 +68,6 @@ export async function analyse(url: string, ...expectedTypes: string[]) {
     // can handle the error better, but maybe CORS error happened so:
     return handleNonFetchableUrl(url);
   }
-  console.log(response)
 
   if (!response.ok) {
     response = await fetch(url + "/info.json");
@@ -91,7 +90,7 @@ export async function analyse(url: string, ...expectedTypes: string[]) {
   } catch {
     return null;
   }
-  console.log(analyseJson(data, url))
+
   return await analyseJson(data, url);
 }
 
@@ -119,7 +118,7 @@ async function analyseJson(data: any, url: string) {
     return null;
   }
   const vault = new IIIFVault.Vault();
-  const vaultData = await vault.load(url); // we could use dataId here, but just in case it's wrong...
+  const vaultData = await vault.load(url, data); // we could use dataId here, but just in case it's wrong...
   if (!vaultData) {
     return;
   }

--- a/manifest-editor/src/hooks/useCanvasSubset.ts
+++ b/manifest-editor/src/hooks/useCanvasSubset.ts
@@ -1,0 +1,29 @@
+import { Reference } from "@iiif/presentation-3";
+import { useResourceContext, useVaultSelector } from "react-iiif-vault";
+import { IIIFStore } from "@iiif/vault/dist";
+
+export function useCanvasSubset(idsOrRefs?: Array<string | Reference>) {
+  const ctx = useResourceContext();
+  const manifestId = ctx.manifest;
+  const refs = idsOrRefs ? idsOrRefs.map((item) => (typeof item === "string" ? item : item?.id)) : [];
+  return useVaultSelector(
+    (s: IIIFStore) => {
+      const manifest = manifestId ? s.iiif.entities.Manifest[manifestId] : undefined;
+      const items = manifest?.items || [];
+
+      if (typeof idsOrRefs === "undefined") {
+        return items;
+      }
+
+      const newItems = [];
+      for (const item of manifest?.items || []) {
+        if (refs.indexOf(item.id) !== -1) {
+          newItems.push(item);
+        }
+      }
+
+      return newItems;
+    },
+    [refs.join("/")]
+  );
+}

--- a/manifest-editor/src/hooks/useCanvasSubset.ts
+++ b/manifest-editor/src/hooks/useCanvasSubset.ts
@@ -1,6 +1,6 @@
 import { Reference } from "@iiif/presentation-3";
 import { useResourceContext, useVaultSelector } from "react-iiif-vault";
-import { IIIFStore } from "@iiif/vault/dist";
+import { IIIFStore } from "@iiif/vault";
 
 export function useCanvasSubset(idsOrRefs?: Array<string | Reference>) {
   const ctx = useResourceContext();

--- a/manifest-editor/src/hooks/usePasteCanvas.ts
+++ b/manifest-editor/src/hooks/usePasteCanvas.ts
@@ -3,18 +3,51 @@ import { createCanvasFromImageService } from "../iiif-builder-extensions/create-
 import { useResourceContext, useVault } from "react-iiif-vault";
 import { useMemo } from "react";
 import { IIIFBuilder } from "iiif-builder";
+import { CanvasNormalized, ManifestNormalized } from "@iiif/presentation-3";
+import { unstable_batchedUpdates } from "react-dom";
+import { reorderEntityField } from "@iiif/vault/actions";
 
-export function usePasteCanvas() {
+export function usePasteCanvas(onComplete?: (canvas: CanvasNormalized) => void) {
   const ctx = useResourceContext();
   const vault = useVault();
   const builder = useMemo(() => new IIIFBuilder(vault), [vault]);
 
   return function onPaste(result: any) {
     if (ctx.manifest && result.type === "Image") {
-      createCanvasFromImage(builder, ctx.manifest, result);
+      return createCanvasFromImage(builder, ctx.manifest, result);
     }
     if (ctx.manifest && result.type.startsWith("ImageService")) {
-      createCanvasFromImageService(builder, ctx.manifest, result);
+      return createCanvasFromImageService(builder, ctx.manifest, result);
     }
+  };
+}
+
+export function usePasteAfterCanvas() {
+  const vault = useVault();
+  const ctx = useResourceContext();
+  const pasteCanvas = usePasteCanvas();
+  return (canvasId: string) => (data: any) => {
+    const newCanvas = pasteCanvas(data);
+    if (!ctx.manifest || !newCanvas) {
+      return;
+    }
+    const manifest = vault.get<ManifestNormalized>(ctx.manifest);
+    const fromPosition = manifest.items.findIndex((r) => r.id === newCanvas.id);
+    const toPosition = manifest.items.findIndex((r) => r.id === canvasId);
+    if (fromPosition + 1 === toPosition) {
+      return;
+    }
+
+    unstable_batchedUpdates(() => {
+      vault.dispatch(
+        reorderEntityField({
+          id: manifest.id,
+          type: "Manifest",
+          endIndex: toPosition + 1,
+          startIndex: fromPosition,
+          key: "items",
+        })
+      );
+    });
   };
 }

--- a/manifest-editor/src/hooks/usePasteCanvas.ts
+++ b/manifest-editor/src/hooks/usePasteCanvas.ts
@@ -1,0 +1,20 @@
+import { createCanvasFromImage } from "../iiif-builder-extensions/create-canvas-from-image";
+import { createCanvasFromImageService } from "../iiif-builder-extensions/create-canvas-from-image-service";
+import { useResourceContext, useVault } from "react-iiif-vault";
+import { useMemo } from "react";
+import { IIIFBuilder } from "iiif-builder";
+
+export function usePasteCanvas() {
+  const ctx = useResourceContext();
+  const vault = useVault();
+  const builder = useMemo(() => new IIIFBuilder(vault), [vault]);
+
+  return function onPaste(result: any) {
+    if (ctx.manifest && result.type === "Image") {
+      createCanvasFromImage(builder, ctx.manifest, result);
+    }
+    if (ctx.manifest && result.type.startsWith("ImageService")) {
+      createCanvasFromImageService(builder, ctx.manifest, result);
+    }
+  };
+}

--- a/manifest-editor/src/icons/PreviewIcon.tsx
+++ b/manifest-editor/src/icons/PreviewIcon.tsx
@@ -1,11 +1,10 @@
-export const PreviewIcon: React.FC = () => (
-  <svg version="1.2" overflow="visible" preserveAspectRatio="none" viewBox="0 0 24 24" width="24" height="1rem">
-    <g>
-      <path
-        d="M10 8v8l5-4-5-4zm9-5H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14z"
-        style={{ fill: "rgb(52, 152, 219)" }}
-        vectorEffect="non-scaling-stroke"
-      />
-    </g>
-  </svg>
-);
+import * as React from "react";
+
+export function PreviewIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg height="1em" viewBox="0 0 24 24" width="1em" {...props}>
+      <path d="M0 0h24v24H0z" fill="none" />
+      <path d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z" />
+    </svg>
+  );
+}

--- a/manifest-editor/src/iiif-builder-extensions/create-canvas-from-image-service.ts
+++ b/manifest-editor/src/iiif-builder-extensions/create-canvas-from-image-service.ts
@@ -1,0 +1,36 @@
+import { IIIFBuilder } from "iiif-builder";
+import { ImageService } from "@iiif/presentation-3";
+import { v4 } from "uuid";
+
+export function createCanvasFromImageService(
+  builder: IIIFBuilder,
+  manifestId: string,
+  imageService: ImageService & { height?: number; width?: number; format?: string },
+  options?: { newCanvasId?: string; imageId?: string }
+) {
+  const newCanvasID = options?.newCanvasId || `https://example.org/canvas/${v4()}`;
+  const imageId = options?.imageId || `https://example.org/image/${v4()}`;
+
+  builder.editManifest(manifestId, (manifest) => {
+    manifest.createCanvas(newCanvasID, (canvas: any) => {
+      canvas.entity.id = newCanvasID;
+      canvas.height = imageService.height;
+      canvas.width = imageService.width;
+      canvas.createAnnotation(`${newCanvasID}/painting`, {
+        id: `${newCanvasID}/painting`,
+        type: "Annotation",
+        motivation: "painting",
+        body: [
+          {
+            id: imageId,
+            type: "Image",
+            format: imageService.format || "image/jpg",
+            height: imageService.height,
+            width: imageService.width,
+            service: [imageService],
+          },
+        ],
+      });
+    });
+  });
+}

--- a/manifest-editor/src/iiif-builder-extensions/create-canvas-from-image-service.ts
+++ b/manifest-editor/src/iiif-builder-extensions/create-canvas-from-image-service.ts
@@ -1,5 +1,5 @@
 import { IIIFBuilder } from "iiif-builder";
-import { ImageService } from "@iiif/presentation-3";
+import { CanvasNormalized, ImageService } from "@iiif/presentation-3";
 import { v4 } from "uuid";
 
 export function createCanvasFromImageService(
@@ -33,4 +33,6 @@ export function createCanvasFromImageService(
       });
     });
   });
+
+  return builder.vault.get<CanvasNormalized>(newCanvasID);
 }

--- a/manifest-editor/src/iiif-builder-extensions/create-canvas-from-image.ts
+++ b/manifest-editor/src/iiif-builder-extensions/create-canvas-from-image.ts
@@ -1,0 +1,32 @@
+import { IIIFBuilder } from "iiif-builder";
+import { ExternalWebResource } from "@iiif/presentation-3";
+import { v4 } from "uuid";
+
+export function createCanvasFromImage(
+  builder: IIIFBuilder,
+  manifestId: string,
+  image: ExternalWebResource & { width?: number; height?: number },
+  options?: { newCanvasId?: string }
+) {
+  const newCanvasID = options?.newCanvasId || `https://example.org/canvas/${v4()}`;
+
+  builder.editManifest(manifestId, (manifest: any) => {
+    manifest.createCanvas(newCanvasID, (canvas: any) => {
+      canvas.entity.id = newCanvasID;
+      canvas.height = image.height;
+      canvas.width = image.width;
+      canvas.createAnnotation(`${newCanvasID}/painting`, {
+        id: `${newCanvasID}/painting`,
+        type: "Annotation",
+        motivation: "painting",
+        body: {
+          id: image.id,
+          type: "Image",
+          format: image.format,
+          height: image.height,
+          width: image.width,
+        },
+      });
+    });
+  });
+}

--- a/manifest-editor/src/iiif-builder-extensions/create-canvas-from-image.ts
+++ b/manifest-editor/src/iiif-builder-extensions/create-canvas-from-image.ts
@@ -1,5 +1,5 @@
 import { IIIFBuilder } from "iiif-builder";
-import { ExternalWebResource } from "@iiif/presentation-3";
+import { CanvasNormalized, ExternalWebResource } from "@iiif/presentation-3";
 import { v4 } from "uuid";
 
 export function createCanvasFromImage(
@@ -29,4 +29,6 @@ export function createCanvasFromImage(
       });
     });
   });
+
+  return builder.vault.get<CanvasNormalized>(newCanvasID);
 }

--- a/manifest-editor/src/madoc/components/EmptyState.tsx
+++ b/manifest-editor/src/madoc/components/EmptyState.tsx
@@ -1,0 +1,27 @@
+import styled, { css } from "styled-components";
+
+export const EmptyState = styled.div<{ $box?: boolean; $noMargin?: boolean }>`
+  text-align: center;
+  color: #666;
+  font-size: 0.8em;
+  padding: 1.5em;
+  width: 100%;
+  margin: 100px 10px 10px 10px;
+
+  ${(props) =>
+    props.$noMargin &&
+    css`
+      margin-top: 10px;
+    `}
+
+  ${(props) =>
+    props.$box &&
+    css`
+      border-radius: 3px;
+      background: #eee;
+    `}
+
+  & ~ & {
+    margin-top: 0;
+  }
+`;

--- a/manifest-editor/src/navigation/CanvasList/CanvasList.styles.ts
+++ b/manifest-editor/src/navigation/CanvasList/CanvasList.styles.ts
@@ -1,0 +1,66 @@
+import styled, { css } from "styled-components";
+import { mainColor } from "../../themes/tokens";
+
+const Container = styled.div`
+  padding-bottom: 1.2em;
+  flex: 1;
+  overflow-y: auto;
+  width: 100%;
+`;
+
+const ItemContainer = styled.div<{ $selected?: boolean }>`
+  padding: 0.75em 1em;
+  border-bottom: 1px solid #eee;
+  width: 100%;
+  color: #333;
+
+  &:hover {
+    background: #f9f9f9;
+  }
+
+  ${(props) =>
+    props.$selected &&
+    css`
+      background: ${mainColor};
+      color: #fff;
+
+      &:hover {
+        background: ${mainColor};
+      }
+    `}
+`;
+
+const ItemIdentifier = styled.div`
+  color: #999;
+  background: #eee;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  padding: 0.4em;
+  font-size: 0.75em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: none;
+`;
+
+const ItemLabel = styled.div<{ $unwrap?: boolean }>`
+  white-space: nowrap;
+  font-size: 0.9em;
+
+  > ${ItemIdentifier} {
+    margin-block-start: 1em;
+  }
+
+  ${(props) =>
+    props.$unwrap &&
+    css`
+      white-space: normal;
+    `}
+`;
+
+export const CanvasListStyles = {
+  Container,
+  ItemContainer,
+
+  ItemIdentifier,
+  ItemLabel,
+};

--- a/manifest-editor/src/navigation/CanvasList/CanvasList.tsx
+++ b/manifest-editor/src/navigation/CanvasList/CanvasList.tsx
@@ -1,0 +1,21 @@
+import { CanvasContext, useManifest } from "react-iiif-vault";
+import invariant from "tiny-invariant";
+import { getValue } from "@iiif/vault-helpers";
+import { CanvasListItem } from "./components/CanvasListItem";
+import { CanvasListStyles } from "./CanvasList.styles";
+
+export function CanvasList() {
+  const manifest = useManifest();
+
+  invariant(manifest, "No manifest selected");
+
+  return (
+    <CanvasListStyles.Container>
+      {manifest.items.map((canvas) => (
+        <CanvasContext key={canvas.id} canvas={canvas.id}>
+          <CanvasListItem />
+        </CanvasContext>
+      ))}
+    </CanvasListStyles.Container>
+  );
+}

--- a/manifest-editor/src/navigation/CanvasList/components/CanvasListItem.tsx
+++ b/manifest-editor/src/navigation/CanvasList/components/CanvasListItem.tsx
@@ -1,0 +1,26 @@
+import { useCanvas } from "react-iiif-vault";
+import { getValue } from "@iiif/vault-helpers";
+import invariant from "tiny-invariant";
+import { CanvasListStyles as S } from "../CanvasList.styles";
+import { useAppState } from "../../../shell/AppContext/AppContext";
+
+export function CanvasListItem() {
+  const canvas = useCanvas();
+  const appState = useAppState();
+
+  invariant(canvas);
+
+  const selected = appState.state.canvasId === canvas.id;
+
+  return (
+    <S.ItemContainer
+      $selected={selected}
+      onClick={() => {
+        appState.setState({ canvasId: canvas.id })
+      }}
+    >
+      <S.ItemLabel $unwrap={selected}>{getValue(canvas.label)}</S.ItemLabel>
+      <S.ItemIdentifier>{canvas.id}</S.ItemIdentifier>
+    </S.ItemContainer>
+  );
+}

--- a/manifest-editor/src/navigation/CanvasList/components/CanvasListItem.tsx
+++ b/manifest-editor/src/navigation/CanvasList/components/CanvasListItem.tsx
@@ -3,6 +3,7 @@ import { getValue } from "@iiif/vault-helpers";
 import invariant from "tiny-invariant";
 import { CanvasListStyles as S } from "../CanvasList.styles";
 import { useAppState } from "../../../shell/AppContext/AppContext";
+import { UniversalCopyTarget } from "../../../shell/Universal/UniversalCopyPaste";
 
 export function CanvasListItem() {
   const canvas = useCanvas();
@@ -13,14 +14,16 @@ export function CanvasListItem() {
   const selected = appState.state.canvasId === canvas.id;
 
   return (
-    <S.ItemContainer
+    <UniversalCopyTarget
+      as={S.ItemContainer}
+      reference={{ id: canvas.id, type: "Canvas" }}
       $selected={selected}
       onClick={() => {
-        appState.setState({ canvasId: canvas.id })
+        appState.setState({ canvasId: canvas.id });
       }}
     >
       <S.ItemLabel $unwrap={selected}>{getValue(canvas.label)}</S.ItemLabel>
       <S.ItemIdentifier>{canvas.id}</S.ItemIdentifier>
-    </S.ItemContainer>
+    </UniversalCopyTarget>
   );
 }

--- a/manifest-editor/src/navigation/CanvasVerticalThumbnails/CanvasVerticalThumbnails.styles.ts
+++ b/manifest-editor/src/navigation/CanvasVerticalThumbnails/CanvasVerticalThumbnails.styles.ts
@@ -1,0 +1,48 @@
+import styled, { css } from "styled-components";
+import { mainColor } from "../../themes/tokens";
+
+const Container = styled.div`
+  width: 100%;
+`;
+
+const Figure = styled.figure<{ $selected?: boolean }>`
+  position: relative;
+  min-height: 100px;
+  margin: 1em;
+  border-radius: 3px;
+  display: flex;
+  background: #f9f9f9;
+  //padding: 0.2em;
+
+  ${(props) =>
+    props.$selected &&
+    css`
+      outline: 2px solid ${mainColor};
+    `}
+
+  img {
+    pointer-events: none;
+    width: 100%;
+  }
+`;
+
+const Caption = styled.figcaption`
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  position: absolute;
+  left: 0.5em;
+  bottom: 0.5em;
+  border-radius: 3px;
+  font-size: 0.75em;
+  padding: 0.5em 1em;
+  max-height: 4.5em;
+  overflow-y: auto;
+  backdrop-filter: blur(5px);
+  margin-right: 0.5em;
+`;
+
+export const CanvasVerticalStyles = {
+  Container,
+  Figure,
+  Caption,
+};

--- a/manifest-editor/src/navigation/CanvasVerticalThumbnails/CanvasVerticalThumbnails.tsx
+++ b/manifest-editor/src/navigation/CanvasVerticalThumbnails/CanvasVerticalThumbnails.tsx
@@ -1,0 +1,55 @@
+import { CanvasVerticalStyles as S } from "./CanvasVerticalThumbnails.styles";
+import { useCanvasSubset } from "../../hooks/useCanvasSubset";
+import { CanvasNormalized, Reference } from "@iiif/presentation-3";
+import { CanvasContext, useVault } from "react-iiif-vault";
+import { CanvasThumbnail } from "../../components/organisms/CanvasThumbnail/CanvasThumbnail";
+import { getValue } from "@iiif/vault-helpers";
+import { useAppState } from "../../shell/AppContext/AppContext";
+import { UniversalCopyTarget } from "../../shell/Universal/UniversalCopyPaste";
+import { useLayoutEffect } from "react";
+
+interface CanvasVerticalThumbnailsProps {
+  ids?: Array<Reference | string>;
+  onClick?: (id: string) => void;
+}
+
+export function CanvasVerticalThumbnails(props: CanvasVerticalThumbnailsProps) {
+  const vault = useVault();
+  const canvases = useCanvasSubset(props.ids);
+  const appState = useAppState();
+
+  useLayoutEffect(() => {
+    if (appState.state.canvasId) {
+      const found = document.querySelector(`[data-canvas-thumb-id="${appState.state.canvasId}"]`);
+      if (found) {
+        found.scrollIntoView({
+          block: "nearest",
+          behavior: "auto",
+        });
+      }
+    }
+  }, [appState.state.canvasId]);
+
+  return (
+    <S.Container>
+      {canvases.map((canvasRef) => {
+        const canvas = vault.get<CanvasNormalized>(canvasRef);
+        return (
+          <CanvasContext key={canvas.id} canvas={canvas.id}>
+            <UniversalCopyTarget
+              as={S.Figure}
+              reference={{ id: canvas.id, type: "Canvas" }}
+              onClick={() => (props.onClick ? props.onClick(canvas.id) : appState.setState({ canvasId: canvas.id }))}
+              style={{ aspectRatio: `${canvas.width}/${canvas.height}` }}
+              $selected={appState.state.canvasId === canvas.id}
+              data-canvas-thumb-id={canvas.id}
+            >
+              <CanvasThumbnail fluid />
+              <S.Caption>{getValue(canvas.label)}</S.Caption>
+            </UniversalCopyTarget>
+          </CanvasContext>
+        );
+      })}
+    </S.Container>
+  );
+}

--- a/manifest-editor/src/navigation/RangeNavigation/RangeNavigation.styles.ts
+++ b/manifest-editor/src/navigation/RangeNavigation/RangeNavigation.styles.ts
@@ -71,6 +71,7 @@ const ItemLabel = styled.div<{ $unwrap?: boolean }>`
   font-size: 0.9em;
   overflow: hidden;
   padding: 0.5em 1em;
+  flex: 1;
   > ${ItemIdentifier} {
     margin-block-start: 1em;
   }
@@ -104,7 +105,7 @@ const SplitLabel = styled.div`
 const Preview = styled.button`
   display: flex;
   align-self: center;
-  margin: 0.2em 0.2em 0.2em auto;
+  margin: 0.2em;
   border-radius: 3px;
   padding: 0.4em;
   border: none;
@@ -113,7 +114,7 @@ const Preview = styled.button`
   cursor: pointer;
 
   svg {
-    fill: rgba(255, 255, 255, 0.6);
+    fill: rgba(0, 0, 0, 0.6);
   }
 
   &:hover {

--- a/manifest-editor/src/navigation/RangeNavigation/RangeNavigation.styles.ts
+++ b/manifest-editor/src/navigation/RangeNavigation/RangeNavigation.styles.ts
@@ -1,0 +1,109 @@
+import styled, { css } from "styled-components";
+import { lightgrey, mainColor } from "../../themes/tokens";
+
+const Container = styled.div`
+  position: relative;
+  flex: 1;
+  overflow-y: auto;
+  width: 100%;
+  padding: 1em;
+`;
+
+const ItemOuterContainer = styled.div`
+  padding: 0.5em 0;
+`;
+
+const ItemContainer = styled.div<{ $selected?: boolean; $leaf?: boolean; $withSelector?: boolean }>`
+  padding: 0.5em 1em;
+  width: 100%;
+  color: #333;
+  border-radius: 3px;
+
+  ${(props) =>
+    props.$leaf &&
+    css`
+      &:hover {
+        background: #f9f9f9;
+      }
+    `}
+
+  ${(props) =>
+    props.$selected &&
+    props.$leaf &&
+    !props.$withSelector &&
+    css`
+      background: ${mainColor};
+      color: #fff;
+
+      &:hover {
+        background: ${mainColor};
+      }
+    `}
+
+  ${(props) =>
+    props.$selected &&
+    props.$leaf &&
+    props.$withSelector &&
+    css`
+      background: #e2ecff;
+      color: #000;
+
+      &:hover {
+        color: #000;
+        background: #e2ecff;
+      }
+    `}
+`;
+
+const ItemIdentifier = styled.div`
+  color: #999;
+  background: #eee;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  padding: 0.4em;
+  font-size: 0.75em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: none;
+`;
+
+const ItemLabel = styled.div<{ $unwrap?: boolean }>`
+  white-space: nowrap;
+  font-size: 0.9em;
+  overflow: hidden;
+
+  > ${ItemIdentifier} {
+    margin-block-start: 1em;
+  }
+
+  ${(props) =>
+    props.$unwrap &&
+    css`
+      white-space: normal;
+    `}
+`;
+
+const NestedContainer = styled.div`
+  margin-left: 0.4em;
+  margin-top: 1em;
+`;
+
+const CurrentRange = styled.div`
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.4);
+  border-bottom: 1px solid #fff;
+  position: sticky;
+  top: -1em;
+  backdrop-filter: blur(4px);
+  padding: 1em;
+`;
+
+export const RangeNavigationStyles = {
+  Container,
+  ItemContainer,
+  NestedContainer,
+  ItemOuterContainer,
+  ItemIdentifier,
+  ItemLabel,
+  CurrentRange,
+};

--- a/manifest-editor/src/navigation/RangeNavigation/RangeNavigation.styles.ts
+++ b/manifest-editor/src/navigation/RangeNavigation/RangeNavigation.styles.ts
@@ -14,7 +14,6 @@ const ItemOuterContainer = styled.div`
 `;
 
 const ItemContainer = styled.div<{ $selected?: boolean; $leaf?: boolean; $withSelector?: boolean }>`
-  padding: 0.5em 1em;
   width: 100%;
   color: #333;
   border-radius: 3px;
@@ -71,7 +70,7 @@ const ItemLabel = styled.div<{ $unwrap?: boolean }>`
   white-space: nowrap;
   font-size: 0.9em;
   overflow: hidden;
-
+  padding: 0.5em 1em;
   > ${ItemIdentifier} {
     margin-block-start: 1em;
   }
@@ -98,6 +97,33 @@ const CurrentRange = styled.div`
   padding: 1em;
 `;
 
+const SplitLabel = styled.div`
+  display: flex;
+`;
+
+const Preview = styled.button`
+  display: flex;
+  align-self: center;
+  margin: 0.2em 0.2em 0.2em auto;
+  border-radius: 3px;
+  padding: 0.4em;
+  border: none;
+  background: transparent;
+  font-size: 1em;
+  cursor: pointer;
+
+  svg {
+    fill: rgba(255, 255, 255, 0.6);
+  }
+
+  &:hover {
+    background: #f9f9f9;
+    svg {
+      fill: ${mainColor};
+    }
+  }
+`;
+
 export const RangeNavigationStyles = {
   Container,
   ItemContainer,
@@ -106,4 +132,6 @@ export const RangeNavigationStyles = {
   ItemIdentifier,
   ItemLabel,
   CurrentRange,
+  SplitLabel,
+  Preview,
 };

--- a/manifest-editor/src/navigation/RangeNavigation/RangeNavigation.tsx
+++ b/manifest-editor/src/navigation/RangeNavigation/RangeNavigation.tsx
@@ -1,0 +1,48 @@
+import { RangeContext, useManifest, useVault } from "react-iiif-vault";
+import invariant from "tiny-invariant";
+import { ViewRange } from "./components/ViewRange";
+import { EmptyCanvasState } from "../../components/organisms/EmptyCanvasState/EmptyCanvasState";
+import { EmptyState } from "../../madoc/components/EmptyState";
+import { RangeNavigationStyles as S } from "./RangeNavigation.styles";
+import { findManifestSelectedRange, findSelectedRange } from "./components/ViewRange.helpers";
+import { useAppState } from "../../shell/AppContext/AppContext";
+import { getValue } from "@iiif/vault-helpers";
+import { useLayoutEffect } from "react";
+
+export function RangeNavigation() {
+  const manifest = useManifest();
+  const vault = useVault();
+  const appState = useAppState();
+
+  invariant(manifest);
+
+  const selected = findManifestSelectedRange(vault, manifest, appState.state.canvasId);
+
+  useLayoutEffect(() => {
+    if (selected) {
+      const found = document.querySelector(`[data-range-id="${selected.id}"]`);
+      if (found) {
+        found.scrollIntoView({
+          block: "nearest",
+          behavior: "auto",
+        });
+      }
+    }
+  }, [selected]);
+
+  if (!manifest.structures.length) {
+    return <EmptyState>No structure information</EmptyState>;
+  }
+
+  return (
+    <S.Container>
+      {selected ? <S.CurrentRange>{getValue(selected.label)}</S.CurrentRange> : null}
+
+      {manifest.structures.map((range) => (
+        <RangeContext key={range.id} range={range.id}>
+          <ViewRange />
+        </RangeContext>
+      ))}
+    </S.Container>
+  );
+}

--- a/manifest-editor/src/navigation/RangeNavigation/components/ViewRange.helpers.ts
+++ b/manifest-editor/src/navigation/RangeNavigation/components/ViewRange.helpers.ts
@@ -16,6 +16,19 @@ export function findFirstCanvasFromRange(vault: Vault, range: RangeNormalized): 
   return null;
 }
 
+export function findAllCanvasesInRange(vault: Vault, range: RangeNormalized): Array<Reference<"Canvas">> {
+  const found = [];
+  for (const inner of range.items) {
+    if (inner.type === "Canvas") {
+      found.push(inner as Reference<"Canvas">);
+    }
+    if (inner.type === "Range") {
+      found.push(...findAllCanvasesInRange(vault, vault.get(inner)));
+    }
+  }
+  return found;
+}
+
 export function findManifestSelectedRange(
   vault: Vault,
   manifest: ManifestNormalized,

--- a/manifest-editor/src/navigation/RangeNavigation/components/ViewRange.helpers.ts
+++ b/manifest-editor/src/navigation/RangeNavigation/components/ViewRange.helpers.ts
@@ -1,5 +1,5 @@
 import { Vault } from "@iiif/vault";
-import { ManifestNormalized, RangeNormalized, Reference } from "@iiif/presentation-3";
+import { ManifestNormalized, RangeItems, RangeNormalized, Reference } from "@iiif/presentation-3";
 
 export function findFirstCanvasFromRange(vault: Vault, range: RangeNormalized): null | Reference<"Canvas"> {
   for (const inner of range.items) {
@@ -29,6 +29,9 @@ export function findAllCanvasesInRange(vault: Vault, range: RangeNormalized): Ar
     if (inner.type === "Range") {
       found.push(...findAllCanvasesInRange(vault, vault.get(inner)));
     }
+    if ((inner as any).type === "SpecificResource") {
+      found.push({ id: (inner as any).source, type: "Canvas" });
+    }
   }
   return found;
 }
@@ -51,6 +54,9 @@ export function findManifestSelectedRange(
 export function findSelectedRange(vault: Vault, range: RangeNormalized, canvasId: string): null | RangeNormalized {
   for (const inner of range.items) {
     const parsedId = inner.id?.split("#")[0];
+    if ((inner as any).type === "SpecificResource" && (inner as any).source === canvasId) {
+      return range;
+    }
     if (inner.type === "Canvas" && canvasId === parsedId) {
       return range;
     }

--- a/manifest-editor/src/navigation/RangeNavigation/components/ViewRange.helpers.ts
+++ b/manifest-editor/src/navigation/RangeNavigation/components/ViewRange.helpers.ts
@@ -1,0 +1,48 @@
+import { Vault } from "@iiif/vault";
+import { ManifestNormalized, RangeNormalized, Reference } from "@iiif/presentation-3";
+
+export function findFirstCanvasFromRange(vault: Vault, range: RangeNormalized): null | Reference<"Canvas"> {
+  for (const inner of range.items) {
+    if (inner.type === "Canvas") {
+      return inner as Reference<"Canvas">;
+    }
+    if (inner.type === "Range") {
+      const found = findFirstCanvasFromRange(vault, vault.get(inner));
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return null;
+}
+
+export function findManifestSelectedRange(
+  vault: Vault,
+  manifest: ManifestNormalized,
+  canvasId: string
+): null | RangeNormalized {
+  for (const range of manifest.structures) {
+    const found = findSelectedRange(vault, vault.get(range), canvasId);
+    if (found) {
+      return found;
+    }
+  }
+
+  return null;
+}
+
+export function findSelectedRange(vault: Vault, range: RangeNormalized, canvasId: string): null | RangeNormalized {
+  for (const inner of range.items) {
+    const parsedId = inner.id?.split("#")[0];
+    if (inner.type === "Canvas" && canvasId === parsedId) {
+      return range;
+    }
+    if (inner.type === "Range") {
+      const found = findSelectedRange(vault, vault.get(inner), canvasId);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return null;
+}

--- a/manifest-editor/src/navigation/RangeNavigation/components/ViewRange.helpers.ts
+++ b/manifest-editor/src/navigation/RangeNavigation/components/ViewRange.helpers.ts
@@ -17,10 +17,14 @@ export function findFirstCanvasFromRange(vault: Vault, range: RangeNormalized): 
 }
 
 export function findAllCanvasesInRange(vault: Vault, range: RangeNormalized): Array<Reference<"Canvas">> {
-  const found = [];
+  const found: Reference<"Canvas">[] = [];
   for (const inner of range.items) {
     if (inner.type === "Canvas") {
-      found.push(inner as Reference<"Canvas">);
+      if (inner.id.indexOf("#") !== -1) {
+        found.push({ id: inner.id.split("#")[0], type: "Canvas" });
+      } else {
+        found.push(inner as Reference<"Canvas">);
+      }
     }
     if (inner.type === "Range") {
       found.push(...findAllCanvasesInRange(vault, vault.get(inner)));

--- a/manifest-editor/src/navigation/RangeNavigation/components/ViewRange.tsx
+++ b/manifest-editor/src/navigation/RangeNavigation/components/ViewRange.tsx
@@ -5,8 +5,9 @@ import { useAppState } from "../../../shell/AppContext/AppContext";
 import { useMemo } from "react";
 import { findAllCanvasesInRange, findFirstCanvasFromRange } from "./ViewRange.helpers";
 import { RangeNavigationStyles as S } from "../RangeNavigation.styles";
-import { useLayoutActions } from "../../../shell/Layout/Layout.context";
+import { useLayoutActions, useLayoutState } from "../../../shell/Layout/Layout.context";
 import { PreviewIcon } from "../../../icons/PreviewIcon";
+import { UniversalCopyTarget } from "../../../shell/Universal/UniversalCopyPaste";
 
 export function ViewRange() {
   const range = useRange();
@@ -16,6 +17,8 @@ export function ViewRange() {
   const parsedFirstId = first ? first.id?.split("#")[0] : null;
   const selected = first && parsedFirstId === appState.state.canvasId;
   const layouts = useLayoutActions();
+  const state = useLayoutState();
+
   const vault = useVault();
 
   invariant(range);
@@ -41,11 +44,20 @@ export function ViewRange() {
         appState.setState({ canvasId: parsedId });
       }
     }
+
+    if (state.centerPanel.state.canvasIds) {
+      onClickPreview();
+    }
   }
 
   return (
-    <S.ItemOuterContainer data-range-id={range.id}>
-      <S.ItemContainer $leaf={!hasSubsequentRanges} $selected={selected} $withSelector={first?.id.indexOf("#") !== -1}>
+    <UniversalCopyTarget as={S.ItemOuterContainer} reference={range}>
+      <S.ItemContainer
+        $leaf={!hasSubsequentRanges}
+        $selected={selected}
+        $withSelector={first?.id.indexOf("#") !== -1}
+        data-range-id={range.id}
+      >
         <S.SplitLabel>
           <S.ItemLabel onClick={onClick}>{getValue(range.label)}</S.ItemLabel>
           <S.Preview onClick={onClickPreview}>
@@ -68,6 +80,6 @@ export function ViewRange() {
           </S.NestedContainer>
         ) : null}
       </S.ItemContainer>
-    </S.ItemOuterContainer>
+    </UniversalCopyTarget>
   );
 }

--- a/manifest-editor/src/navigation/RangeNavigation/components/ViewRange.tsx
+++ b/manifest-editor/src/navigation/RangeNavigation/components/ViewRange.tsx
@@ -1,0 +1,55 @@
+import { RangeContext, useRange, useVault } from "react-iiif-vault";
+import { getValue } from "@iiif/vault-helpers";
+import invariant from "tiny-invariant";
+import { useAppState } from "../../../shell/AppContext/AppContext";
+import { useMemo } from "react";
+import { findFirstCanvasFromRange } from "./ViewRange.helpers";
+import { RangeNavigationStyles as S } from "../RangeNavigation.styles";
+
+export function ViewRange() {
+  const range = useRange();
+  const appState = useAppState();
+  const first = useMemo(() => range?.items.find((i) => i.type === "Canvas"), [range]);
+  const hasSubsequentRanges = useMemo(() => !!range?.items.find((i) => i.type === "Range"), [range]);
+  const parsedFirstId = first ? first.id?.split("#")[0] : null;
+  const selected = first && parsedFirstId === appState.state.canvasId;
+  const vault = useVault();
+
+  invariant(range);
+
+  function onClick() {
+    if (first) {
+      appState.setState({ canvasId: parsedFirstId });
+    } else if (range) {
+      // ... recursively find..
+      const found = findFirstCanvasFromRange(vault, range);
+      if (found) {
+        const parsedId = found.id?.split("#")[0];
+        appState.setState({ canvasId: parsedId });
+      }
+    }
+  }
+
+  return (
+    <S.ItemOuterContainer data-range-id={range.id}>
+      <S.ItemContainer $leaf={!hasSubsequentRanges} $selected={selected} $withSelector={first?.id.indexOf("#") !== -1}>
+        <S.ItemLabel onClick={onClick}>{getValue(range.label)}</S.ItemLabel>
+        {hasSubsequentRanges ? (
+          <S.NestedContainer>
+            {range.items.map((range) => {
+              if (range.type === "Canvas") {
+                return null;
+              }
+
+              return (
+                <RangeContext key={range.id} range={range.id}>
+                  <ViewRange />
+                </RangeContext>
+              );
+            })}
+          </S.NestedContainer>
+        ) : null}
+      </S.ItemContainer>
+    </S.ItemOuterContainer>
+  );
+}

--- a/manifest-editor/src/navigation/RangeNavigation/components/ViewRange.tsx
+++ b/manifest-editor/src/navigation/RangeNavigation/components/ViewRange.tsx
@@ -3,8 +3,10 @@ import { getValue } from "@iiif/vault-helpers";
 import invariant from "tiny-invariant";
 import { useAppState } from "../../../shell/AppContext/AppContext";
 import { useMemo } from "react";
-import { findFirstCanvasFromRange } from "./ViewRange.helpers";
+import { findAllCanvasesInRange, findFirstCanvasFromRange } from "./ViewRange.helpers";
 import { RangeNavigationStyles as S } from "../RangeNavigation.styles";
+import { useLayoutActions } from "../../../shell/Layout/Layout.context";
+import { PreviewIcon } from "../../../icons/PreviewIcon";
 
 export function ViewRange() {
   const range = useRange();
@@ -13,9 +15,20 @@ export function ViewRange() {
   const hasSubsequentRanges = useMemo(() => !!range?.items.find((i) => i.type === "Range"), [range]);
   const parsedFirstId = first ? first.id?.split("#")[0] : null;
   const selected = first && parsedFirstId === appState.state.canvasId;
+  const layouts = useLayoutActions();
   const vault = useVault();
 
   invariant(range);
+
+  function onClickPreview() {
+    if (range) {
+      const allItems = findAllCanvasesInRange(vault, range);
+      if (allItems.length > 0) {
+        appState.setState({ canvasId: allItems[0].id });
+        layouts.centerPanel.open({ id: "thumbnail-grid", state: { canvasIds: allItems } });
+      }
+    }
+  }
 
   function onClick() {
     if (first) {
@@ -33,7 +46,12 @@ export function ViewRange() {
   return (
     <S.ItemOuterContainer data-range-id={range.id}>
       <S.ItemContainer $leaf={!hasSubsequentRanges} $selected={selected} $withSelector={first?.id.indexOf("#") !== -1}>
-        <S.ItemLabel onClick={onClick}>{getValue(range.label)}</S.ItemLabel>
+        <S.SplitLabel>
+          <S.ItemLabel onClick={onClick}>{getValue(range.label)}</S.ItemLabel>
+          <S.Preview onClick={onClickPreview}>
+            <PreviewIcon />
+          </S.Preview>
+        </S.SplitLabel>
         {hasSubsequentRanges ? (
           <S.NestedContainer>
             {range.items.map((range) => {

--- a/manifest-editor/src/resource-editors/content-resource/ContentResource.styles.ts
+++ b/manifest-editor/src/resource-editors/content-resource/ContentResource.styles.ts
@@ -1,0 +1,15 @@
+import styled from "styled-components";
+import { InputUnderlined } from "../../editors/Input";
+
+const AnalyseContainer = styled.div`
+  background: red;
+`;
+
+const AnalyseInput = styled(InputUnderlined)`
+  background: red;
+`;
+
+export const ContentResourceStyles = {
+  AnalyseInput,
+  AnalyseContainer,
+};

--- a/manifest-editor/src/resource-editors/content-resource/ContentResourceAnalyseForm.tsx
+++ b/manifest-editor/src/resource-editors/content-resource/ContentResourceAnalyseForm.tsx
@@ -1,0 +1,15 @@
+import { analyse } from "../../helpers/analyse";
+import { ContentResourceStyles as S } from "./ContentResource.styles";
+
+export function ContentResourceAnalyseForm() {
+  // 1. Single box, filled out
+  // 2. Remove box, show loading
+  // 3. Show readonly details, to be confirmed
+  // 4. Redirect to editor.
+
+  return (
+    <S.AnalyseContainer>
+      <S.AnalyseInput />
+    </S.AnalyseContainer>
+  );
+}

--- a/manifest-editor/src/resource-editors/helpers/supports-property.ts
+++ b/manifest-editor/src/resource-editors/helpers/supports-property.ts
@@ -1,0 +1,12 @@
+import { ResourceEditorConfig } from "../../types/resource-editor-config";
+
+export function supportsProperty<T>(list: ResourceEditorConfig[], property: string): T | null {
+  for (const config of list) {
+    const type = typeof config === "string" ? config : config[0];
+    if (type === property) {
+      return typeof config === "string" ? config || {} : config[1] || {};
+    }
+  }
+
+  return null;
+}

--- a/manifest-editor/src/resource-editors/manifest/ManifestDescriptive.tsx
+++ b/manifest-editor/src/resource-editors/manifest/ManifestDescriptive.tsx
@@ -1,14 +1,51 @@
+import { useManifest } from "react-iiif-vault";
+import { ResourceEditingProvider } from "../../shell/ResourceEditingContext/ResourceEditingContext";
+import { ResourceEditorConfig } from "../../types/resource-editor-config";
+import { supportsProperty } from "../helpers/supports-property";
+import { LanguageMapEditor } from "../../editors/generic/LanguageMapEditor/LanguageMapEditor";
+
 export interface ManifestDescriptiveProps {
+  supports: ResourceEditorConfig[];
   editThumbnail?(id: string): void;
   editLogo?(id: string): void;
 }
 
 export function ManifestDescriptive(props: ManifestDescriptiveProps) {
-  // Label
-  // Summary
-  // Rights
-  // Nav date
-  // Thumbnails
-  // Logo
-  return <div>Manifest descriptive</div>;
+  const manifest = useManifest();
+  const label = supportsProperty(props.supports, "label");
+  const summary = supportsProperty(props.supports, "summary");
+
+  return (
+    <div style={{ width: "100%", padding: "0.5em" }}>
+      <ResourceEditingProvider resource={manifest}>
+        {label ? (
+          <LanguageMapEditor
+            dispatchType={"label"}
+            guidanceReference={"https://iiif.io/api/presentation/3.0/#label"}
+            {...label}
+          />
+        ) : null}
+        {summary ? (
+          <LanguageMapEditor
+            dispatchType={"summary"}
+            guidanceReference={"https://iiif.io/api/presentation/3.0/#summary"}
+            {...summary}
+          />
+        ) : null}
+
+        {/* @todo rights */}
+        {/* @todo nav date */}
+        {/*   - Browser date picker */}
+        {/*   - Serialise to and from ISO */}
+        {/* @todo thumbnail */}
+        {/*   - Paste thumbnail image */}
+        {/*   - Paste thumbnail image service (extracting both) */}
+        {/*   - New thumbnail form */}
+        {/*   - Deleting thumbnails */}
+        {/*   - Editing thumbnail (resource/image editor) */}
+        {/* @todo logo */}
+        {/*   - The same as or similar to thumbnail */}
+      </ResourceEditingProvider>
+    </div>
+  );
 }

--- a/manifest-editor/src/shell/AppHeader/AppHeader.tsx
+++ b/manifest-editor/src/shell/AppHeader/AppHeader.tsx
@@ -1,119 +1,27 @@
-import {
-  DraftTitle,
-  Draft,
-  IconButton,
-  Logo,
-  Container,
-  ProjectPreview,
-  Header,
-  DraftsText,
-  DraftTitleEdit,
-  DraftTitleEditInput,
-  DraftTitleEditButton,
-} from "./AppHeader.styles";
-import { useProjectContext } from "../ProjectContext/ProjectContext";
+import { Logo, Container, ProjectPreview, Header } from "./AppHeader.styles";
 import { useApps } from "../AppContext/AppContext";
-import { Button } from "../../atoms/Button";
-import { Dropdown, DropdownDivider, DropdownLabel, DropdownMenu } from "../../atoms/Dropdown";
-import { MenuIcon } from "../../icons/MenuIcon";
 import { PreviewButton } from "../../components/organisms/PreviewButton/PreviewButton";
 import { ShellOptions } from "../../apps/Shell/ShellOptions";
 import { ManifestEditorLogo } from "../../atoms/ManifestEditorLogo";
-import { MappedApp } from "../../apps/app-loader";
-import useDropdownMenu from "react-accessible-dropdown-menu-hook";
 import { useLocalStorage } from "../../madoc/use-local-storage";
-import { FormEvent, useState } from "react";
-import { flushSync } from "react-dom";
+import { DraftTitleEditor } from "./components/DraftTitleEditor";
+import { AppMenu } from "./components/AppMenu";
 
 export function AppHeader() {
-  const { current: currentProject, actions } = useProjectContext();
-  const [isMenuHidden, setIsMenuHidden] = useLocalStorage("menu-hidden");
-  const [editingTitle, setIsEditingTitle] = useState(false);
-  const { apps, changeApp } = useApps();
-  const { current } = useProjectContext();
-  const filteredApps = Object.values(apps).filter((app: MappedApp) => {
-    if (!currentProject && app.metadata.project) {
-      return false;
-    }
-
-    if (app.metadata.type === "launcher") {
-      return false;
-    }
-
-    if (app.metadata.dev && import.meta.env.PROD) {
-      return false;
-    }
-
-    return true;
-  });
-  const { itemProps, buttonProps, isOpen, setIsOpen } = useDropdownMenu(filteredApps.length + 1);
+  const [isMenuHidden] = useLocalStorage("menu-hidden");
+  const { changeApp } = useApps();
 
   return (
     <Header>
       <Container>
-        <Dropdown>
-          <IconButton {...buttonProps}>
-            <MenuIcon />
-          </IconButton>
-          <DropdownMenu $open={isOpen}>
-            <DropdownLabel>Apps</DropdownLabel>
-            <DropdownDivider />
-            {filteredApps.map((app, key) => (
-              <Button
-                key={app.metadata.id}
-                {...(itemProps[key] as any)}
-                onClick={() => {
-                  changeApp({ id: app.metadata.id });
-                  setIsOpen(false);
-                }}
-              >
-                {app.metadata.title}
-              </Button>
-            ))}
-            <DropdownLabel>Quick Settings</DropdownLabel>
-            <DropdownDivider />
-            <Button {...(itemProps[filteredApps.length + 0] as any)} onClick={() => setIsMenuHidden(!isMenuHidden)}>
-              {isMenuHidden ? "Show menu" : "Hide menu"}
-            </Button>
-          </DropdownMenu>
-        </Dropdown>
+        <AppMenu />
 
         <Logo onClick={() => changeApp({ id: "splash" })}>
           <ManifestEditorLogo height={27} width={200} />
         </Logo>
 
         <ProjectPreview>
-          <Draft>
-            <DraftsText>Drafts</DraftsText>
-            {current ? (
-              <>
-                {editingTitle ? (
-                  <DraftTitleEdit
-                    onSubmit={(e: FormEvent<HTMLFormElement>) => {
-                      const form = new FormData(e.target as any);
-                      const data = Object.fromEntries(form.entries());
-                      actions.updateDetails(data as any);
-                      setIsEditingTitle(false);
-                    }}
-                  >
-                    <DraftTitleEditInput id="project-title" defaultValue={current.name} name="name" />
-                    <DraftTitleEditButton>Save</DraftTitleEditButton>
-                  </DraftTitleEdit>
-                ) : (
-                  <DraftTitle
-                    onClick={() => {
-                      flushSync(() => {
-                        setIsEditingTitle(true);
-                      });
-                      document.getElementById("project-title")?.focus();
-                    }}
-                  >
-                    {current.name || "Untitled project"}
-                  </DraftTitle>
-                )}
-              </>
-            ) : null}
-          </Draft>
+          <DraftTitleEditor />
           {/*<ContextButton>{state.canvasId ? "Canvas" : "Manifest"}</ContextButton>*/}
         </ProjectPreview>
 

--- a/manifest-editor/src/shell/AppHeader/components/AppMenu.tsx
+++ b/manifest-editor/src/shell/AppHeader/components/AppMenu.tsx
@@ -1,0 +1,64 @@
+import { IconButton } from "../AppHeader.styles";
+import { MenuIcon } from "../../../icons/MenuIcon";
+import { Dropdown, DropdownDivider, DropdownLabel, DropdownMenu } from "../../../atoms/Dropdown";
+import { Button } from "../../../atoms/Button";
+import { useProjectContext } from "../../ProjectContext/ProjectContext";
+import { useLocalStorage } from "../../../madoc/use-local-storage";
+import { useApps } from "../../AppContext/AppContext";
+import { MappedApp } from "../../../apps/app-loader";
+import useDropdownMenu from "react-accessible-dropdown-menu-hook";
+
+export function AppMenu(props: { hideMenu?: boolean }) {
+  const { current: currentProject } = useProjectContext();
+  const [isMenuHidden, setIsMenuHidden] = useLocalStorage("menu-hidden");
+  const { apps, changeApp } = useApps();
+  const filteredApps = Object.values(apps).filter((app: MappedApp) => {
+    if (!currentProject && app.metadata.project) {
+      return false;
+    }
+
+    if (app.metadata.type === "launcher") {
+      return false;
+    }
+
+    if (app.metadata.dev && import.meta.env.PROD) {
+      return false;
+    }
+
+    return true;
+  });
+  const { itemProps, buttonProps, isOpen, setIsOpen } = useDropdownMenu(filteredApps.length + 1);
+
+  return (
+    <Dropdown>
+      <IconButton {...buttonProps}>
+        <MenuIcon />
+      </IconButton>
+      <DropdownMenu $open={isOpen}>
+        <DropdownLabel>Apps</DropdownLabel>
+        <DropdownDivider />
+        {filteredApps.map((app, key) => (
+          <Button
+            key={app.metadata.id}
+            {...(itemProps[key] as any)}
+            onClick={() => {
+              changeApp({ id: app.metadata.id });
+              setIsOpen(false);
+            }}
+          >
+            {app.metadata.title}
+          </Button>
+        ))}
+        {props.hideMenu ? null : (
+          <>
+            <DropdownLabel>Quick Settings</DropdownLabel>
+            <DropdownDivider />
+            <Button {...(itemProps[filteredApps.length + 0] as any)} onClick={() => setIsMenuHidden(!isMenuHidden)}>
+              {isMenuHidden ? "Show menu" : "Hide menu"}
+            </Button>
+          </>
+        )}
+      </DropdownMenu>
+    </Dropdown>
+  );
+}

--- a/manifest-editor/src/shell/AppHeader/components/DraftTitleEditor.tsx
+++ b/manifest-editor/src/shell/AppHeader/components/DraftTitleEditor.tsx
@@ -1,0 +1,51 @@
+import {
+  Draft,
+  DraftsText,
+  DraftTitle,
+  DraftTitleEdit,
+  DraftTitleEditButton,
+  DraftTitleEditInput,
+} from "../AppHeader.styles";
+import { FormEvent, useState } from "react";
+import { flushSync } from "react-dom";
+import { useProjectContext } from "../../ProjectContext/ProjectContext";
+
+export function DraftTitleEditor() {
+  const { actions } = useProjectContext();
+  const [editingTitle, setIsEditingTitle] = useState(false);
+  const { current } = useProjectContext();
+
+  return (
+    <Draft>
+      <DraftsText>Drafts</DraftsText>
+      {current ? (
+        <>
+          {editingTitle ? (
+            <DraftTitleEdit
+              onSubmit={(e: FormEvent<HTMLFormElement>) => {
+                const form = new FormData(e.target as any);
+                const data = Object.fromEntries(form.entries());
+                actions.updateDetails(data as any);
+                setIsEditingTitle(false);
+              }}
+            >
+              <DraftTitleEditInput id="project-title" defaultValue={current.name} name="name" />
+              <DraftTitleEditButton>Save</DraftTitleEditButton>
+            </DraftTitleEdit>
+          ) : (
+            <DraftTitle
+              onClick={() => {
+                flushSync(() => {
+                  setIsEditingTitle(true);
+                });
+                document.getElementById("project-title")?.focus();
+              }}
+            >
+              {current.name || "Untitled project"}
+            </DraftTitle>
+          )}
+        </>
+      ) : null}
+    </Draft>
+  );
+}

--- a/manifest-editor/src/shell/Layout/Layout.styles.ts
+++ b/manifest-editor/src/shell/Layout/Layout.styles.ts
@@ -40,6 +40,15 @@ export const CenterPanel = styled.div`
   // background: linear-gradient(0deg, rgba(251, 242, 237, 1) 0%, rgba(240, 229, 245, 1) 50%, rgba(236, 245, 255, 1) 100%);
 
   min-width: 320px;
+  display: flex;
+
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+
+  > * {
+    min-width: 0;
+  }
 `;
 
 export const RightPanel = styled.div`

--- a/manifest-editor/src/shell/Layout/components/ModularPanel.tsx
+++ b/manifest-editor/src/shell/Layout/components/ModularPanel.tsx
@@ -115,6 +115,10 @@ const ModularPanelContent = styled.div`
   min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
+
+  > * {
+    min-width: 0;
+  }
 `;
 
 export function ModularPanel({

--- a/manifest-editor/src/shell/Layout/components/ModularPanel.tsx
+++ b/manifest-editor/src/shell/Layout/components/ModularPanel.tsx
@@ -110,6 +110,11 @@ const ModularPanelLabel = styled.h2`
 const ModularPanelContent = styled.div`
   flex: 1 1 0px;
   padding-bottom: 1em;
+  display: flex;
+
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
 `;
 
 export function ModularPanel({

--- a/manifest-editor/src/shell/ProjectContext/ProjectContext.types.tsx
+++ b/manifest-editor/src/shell/ProjectContext/ProjectContext.types.tsx
@@ -1,12 +1,11 @@
-import { Source } from "./types/Source";
 import { Storage } from "./types/Storage";
 import { Publication } from "./types/Publication";
-import { Reference } from "@iiif/presentation-3";
 import { Vault } from "@iiif/vault";
 import { Preview } from "./types/Preview";
 
 export type ProjectContext = ProjectState & {
   actions: ProjectActions;
+  canDelete: boolean;
 };
 
 export interface ProjectState {
@@ -75,25 +74,27 @@ export interface EditorProject {
 
 export interface ProjectBackend {
   saveInterval: number;
-  getAllProjects(): Promise<EditorProject[]>;
+  getAllProjects(fresh?: boolean): Promise<EditorProject[]>;
   getLastProject(): Promise<string | null>;
   setLastProject(id: string): Promise<void>;
+  canDelete(): boolean;
   createProject(project: EditorProject): Promise<void>;
   updateProject(project: EditorProject): Promise<void>;
   deleteProject(id: string): Promise<void>;
 }
 
-export interface ProjectStorage<S extends Storage> {
+export interface ProjectStorage<S extends Storage, DataType = any, Ref extends Storage = any> {
   type: string;
   saveInterval: number;
 
   // Fetching
-  getStorage(id: string): Promise<S | null>;
-  updateStorage(id: string, storage: S): Promise<void>;
-  deleteStorage(id: string): Promise<void>;
+  create(project: EditorProject, data: DataType): Promise<Ref | void>;
+  getStorage(ref: Ref): Promise<S | null>;
+  saveStorage(ref: Ref): Promise<void>;
+  deleteStorage(ref: Ref): Promise<void>;
 
   // Runtime
-  getLatestStorage(project: EditorProject): S;
+  getBackendStorage(project: EditorProject): Ref;
   createVaultInstance(project: EditorProject): [Vault, Promise<void>];
   shouldUpdateWithVault(): boolean;
 }

--- a/manifest-editor/src/shell/ProjectContext/backend/LocalStorageBackend.ts
+++ b/manifest-editor/src/shell/ProjectContext/backend/LocalStorageBackend.ts
@@ -24,6 +24,10 @@ export class LocalStorageBackend implements ProjectBackend {
     }
   }
 
+  canDelete() {
+    return true;
+  }
+
   async getAllProjects(): Promise<EditorProject[]> {
     try {
       const index = await this.getProjectIndex();

--- a/manifest-editor/src/shell/ProjectContext/helpers/ensure-unique-filename.ts
+++ b/manifest-editor/src/shell/ProjectContext/helpers/ensure-unique-filename.ts
@@ -1,0 +1,30 @@
+import { EditorProject } from "../ProjectContext.types";
+import slugify from "slugify";
+
+export function ensureUniqueFilename(project: EditorProject, existing: EditorProject[]) {
+  const filenames = existing.map((project) => project.filename);
+
+  const name = (project.name || project.filename || "Untitled project").toLowerCase();
+
+  if (project.filename && filenames.indexOf(project.filename) !== -1) {
+    // duplicate.
+    project.filename = undefined;
+  }
+
+  if (!project.filename) {
+    let counter = 0;
+    while (!project.filename) {
+      // Create filename.
+      const potentialFilename = `${slugify(name, { lower: true })}${counter ? ` (${counter})` : ""}`;
+      if (filenames.indexOf(potentialFilename) === -1) {
+        project.filename = potentialFilename;
+        project.name = `${project.name} (${counter})`;
+        break;
+      }
+
+      counter++;
+    }
+  }
+
+  console.log({ project, filenames });
+}

--- a/manifest-editor/src/shell/ProjectContext/storage/AbstractVaultLoader.ts
+++ b/manifest-editor/src/shell/ProjectContext/storage/AbstractVaultLoader.ts
@@ -1,0 +1,64 @@
+import { Vault } from "@iiif/vault";
+import { EditorProject, ProjectStorage } from "../ProjectContext.types";
+import { Manifest, Reference } from "@iiif/presentation-3";
+import { ManifestStorage, Storage } from "../types/Storage";
+
+export abstract class AbstractVaultLoader<T extends Storage> implements ProjectStorage<ManifestStorage, Manifest, T> {
+  abstract type: string;
+  vaults: Record<string, Vault | null> = {};
+  saveInterval: number;
+
+  protected constructor(config: Partial<{ saveInterval: number }> = {}) {
+    this.saveInterval = config.saveInterval || 5000;
+  }
+
+  shouldUpdateWithVault() {
+    return true;
+  }
+
+  abstract create(project: EditorProject, data: Manifest): Promise<T>;
+
+  createVaultInstance(project: EditorProject): [Vault, Promise<void>] {
+    const foundVault = this.vaults[project.storage.data.key];
+    if (foundVault) {
+      return [foundVault, Promise.resolve()];
+    }
+
+    const vault = new Vault();
+
+    const promise = async () => {
+      const data = await this.getStorage(project.storage as any);
+      await vault.loadManifest(project.resource.id, JSON.parse(JSON.stringify(data?.data)));
+      this.vaults[project.storage.data.key] = vault;
+    };
+
+    return [vault, promise() as Promise<void>];
+  }
+
+  async saveStorage(storage: T): Promise<void> {
+    const vault = this.vaults[storage.data.key];
+    const manifestRef: Reference<"Manifest"> = {
+      id: storage.data.id,
+      type: "Manifest",
+    };
+
+    // There will only be something to save if there is active vault.
+    if (vault) {
+      const data = vault.toPresentation3<Manifest>(manifestRef);
+      const stored: ManifestStorage = {
+        type: "manifest-storage",
+        data,
+      };
+
+      await this.saveStorageData(stored, storage);
+    }
+  }
+
+  abstract getStorage(storage: T): Promise<ManifestStorage | null>;
+
+  abstract saveStorageData(manifest: ManifestStorage, storage: T): void | Promise<void>;
+
+  abstract deleteStorage(storage: T): Promise<void>;
+
+  abstract getBackendStorage(project: EditorProject): T;
+}

--- a/manifest-editor/src/shell/ProjectContext/storage/LocalStorageLoader.ts
+++ b/manifest-editor/src/shell/ProjectContext/storage/LocalStorageLoader.ts
@@ -1,71 +1,68 @@
 import { EditorProject, ProjectStorage } from "../ProjectContext.types";
 import { Vault } from "@iiif/vault";
-import { Reference } from "@iiif/presentation-3";
-import { ManifestStorage } from "../types/Storage";
+import { Manifest, Reference } from "@iiif/presentation-3";
+import { ManifestKeyedStorage, ManifestStorage } from "../types/Storage";
+import { v4 } from "uuid";
+import { AbstractVaultLoader } from "./AbstractVaultLoader";
+import { writeTextFile } from "@tauri-apps/api/fs";
+import invariant from "tiny-invariant";
 
-export class LocalStorageLoader implements ProjectStorage<ManifestStorage> {
+export class LocalStorageLoader extends AbstractVaultLoader<ManifestKeyedStorage> {
   type = "local-storage";
   namespace: string;
 
-  vaults: Record<string, Vault> = {};
-  saveInterval: number;
+  vaults: Record<string, Vault | null> = {};
 
   constructor(settings?: { namespace?: string }) {
+    super({ saveInterval: 5000 });
     this.namespace = settings?.namespace || "default";
-    this.saveInterval = 5000;
   }
 
   shouldUpdateWithVault() {
     return true;
   }
 
-  createVaultInstance(project: EditorProject): [Vault, Promise<void>] {
-    const data = project.storage.data;
+  async create(project: EditorProject, data: Manifest): Promise<ManifestKeyedStorage> {
+    const key = v4();
 
-    if (this.vaults[project.id]) {
-      return [this.vaults[project.id], Promise.resolve()];
-    }
+    await localStorage.setItem(`${this.namespace}/store/${key}`, JSON.stringify(data));
 
-    const vault = new Vault();
-
-    const promise = vault.loadManifest(project.resource.id, JSON.parse(JSON.stringify(data)));
-    this.vaults[project.id] = vault;
-
-    return [vault, promise as Promise<void>];
+    return {
+      type: "manifest-keyed-storage",
+      data: {
+        id: data.id,
+        key,
+      },
+    };
   }
 
-  async getStorage(id: string): Promise<ManifestStorage | null> {
+  async getStorage(storage: ManifestKeyedStorage): Promise<ManifestStorage | null> {
     try {
-      const item = await localStorage.getItem(`${this.namespace}/store/${id}`);
+      const item = await localStorage.getItem(`${this.namespace}/store/${storage.data.key}`);
+      const manifest = item ? (JSON.parse(item) as Manifest) : null;
 
-      return item ? (JSON.parse(item) as ManifestStorage) : null;
+      invariant(manifest, "Manifest not found");
+
+      return {
+        type: "manifest-storage",
+        data: manifest,
+      };
     } catch (e) {
       return null;
     }
   }
 
-  async updateStorage(id: string, storage: ManifestStorage): Promise<void> {
-    await localStorage.setItem(`${this.namespace}/store/${id}`, JSON.stringify(storage));
+  async saveStorageData(manifestStorage: ManifestStorage, storage: ManifestKeyedStorage): Promise<void> {
+    await localStorage.setItem(`${this.namespace}/store/${storage.data.key}`, JSON.stringify(manifestStorage.data));
   }
 
-  async deleteStorage(id: string): Promise<void> {
-    await localStorage.removeItem(`${this.namespace}/store/${id}`);
+  async deleteStorage(storage: ManifestKeyedStorage): Promise<void> {
+    this.vaults[storage.data.key] = null;
+    await localStorage.removeItem(`${this.namespace}/store/${storage.data.key}`);
   }
 
-  getLatestStorage(project: EditorProject): ManifestStorage {
-    const vault = this.vaults[project.id];
-    const manifestRef: Reference<"Manifest"> = {
-      id: project.storage.data.id,
-      type: "Manifest",
-    };
-
-    if (!vault) {
-      return project.storage as ManifestStorage;
-    }
-
-    return {
-      type: "manifest-storage",
-      data: vault.toPresentation3(manifestRef),
-    };
+  getBackendStorage(project: EditorProject): ManifestKeyedStorage {
+    // This will never change after creation, but other adapters might?
+    return project.storage as ManifestKeyedStorage;
   }
 }

--- a/manifest-editor/src/shell/Universal/UniversalCopyPaste.tsx
+++ b/manifest-editor/src/shell/Universal/UniversalCopyPaste.tsx
@@ -1,0 +1,131 @@
+import { HTMLAttributes, useCallback, useMemo } from "react";
+import { UniversalCopyPasteProps } from "./UniversalCopyPaste.types";
+import { analyse } from "../../helpers/analyse";
+
+export function UniversalCopyTarget<T>({
+  as,
+  onDropReference,
+  reference: _ref,
+  onPasteReference,
+  onPasteLink,
+  onPasteAnalysis,
+  ...props
+}: HTMLAttributes<HTMLElement> & UniversalCopyPasteProps<T> & T) {
+  const Component = (as || "div") as any;
+  const reference = useMemo(() => {
+    return _ref;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [_ref?.id, _ref?.type]);
+
+  const onCopy = useCallback(
+    function onCopy(e: ClipboardEvent) {
+      if (e.defaultPrevented) {
+        return;
+      }
+      e.preventDefault();
+      if (e.clipboardData) {
+        if (reference && reference.id && reference.type) {
+          e.clipboardData.setData(
+            "application/json+vault",
+            JSON.stringify({
+              id: reference.id,
+              type: reference.type,
+            })
+          );
+        }
+      }
+    },
+    [reference]
+  );
+
+  const onPaste = useCallback(async function onPaste(e: ClipboardEvent) {
+    if (e.defaultPrevented) {
+      return;
+    }
+    e.preventDefault();
+    if (e.clipboardData) {
+      if (onPasteReference) {
+        const data = e.clipboardData.getData("application/json+vault");
+        if (data) {
+          try {
+            const dataAsJson = JSON.parse(data);
+            if (dataAsJson && dataAsJson.id && dataAsJson.type) {
+              onPasteReference(dataAsJson);
+            }
+          } catch (e) {
+            // ignore.
+            return;
+          }
+        }
+      }
+
+      if (onPasteLink || onPasteAnalysis) {
+        const data = e.clipboardData.getData("text");
+        if (data.startsWith("http")) {
+          const allLinks = data.split("\n");
+          for (const link of allLinks) {
+            if (onPasteAnalysis) {
+              try {
+                const result = await analyse(link);
+                if (result) {
+                  onPasteAnalysis(result);
+                  continue;
+                }
+              } catch (e) {
+                // let it fallback to onPasteLink
+              }
+            }
+            if (onPasteLink) {
+              onPasteLink(link);
+            }
+          }
+        }
+      }
+    }
+  }, []);
+
+  // @todo not working..
+  const onDragStart = useCallback(function onPaste(e: DragEvent) {
+    if (e.defaultPrevented) {
+      return;
+    }
+    e.preventDefault();
+    if (e.dataTransfer && props.draggable) {
+      e.dataTransfer.effectAllowed = "all";
+
+      if (reference && reference.id && reference.type) {
+        e.dataTransfer.setData(
+          "application/json+vault",
+          JSON.stringify({
+            id: reference.id,
+            type: reference.type,
+          })
+        );
+      }
+    }
+  }, []);
+
+  const onDrop = useCallback(function onPaste(e: DragEvent) {
+    e.preventDefault();
+    if (e.dataTransfer) {
+      if (onDropReference) {
+        const data = e.dataTransfer.getData("application/json+vault");
+        if (data) {
+          try {
+            const dataAsJson = JSON.parse(data);
+            if (dataAsJson && dataAsJson.id && dataAsJson.type) {
+              onDropReference(dataAsJson, e);
+            }
+          } catch (e) {
+            // ignore.
+            return;
+          }
+        }
+      }
+    }
+  }, []);
+
+  return (
+    <Component onCopy={onCopy} onPaste={onPaste} onDrop={onDrop} onDragStart={onDragStart} tabIndex={-1} {...props} />
+  );
+}

--- a/manifest-editor/src/shell/Universal/UniversalCopyPaste.tsx
+++ b/manifest-editor/src/shell/Universal/UniversalCopyPaste.tsx
@@ -44,6 +44,10 @@ export function UniversalCopyTarget<T>({
     }
     e.preventDefault();
     if (e.clipboardData) {
+      if (props.onLoading) {
+        props.onLoading();
+      }
+
       if (onPasteReference) {
         const data = e.clipboardData.getData("application/json+vault");
         if (data) {
@@ -54,7 +58,6 @@ export function UniversalCopyTarget<T>({
             }
           } catch (e) {
             // ignore.
-            return;
           }
         }
       }
@@ -80,6 +83,9 @@ export function UniversalCopyTarget<T>({
             }
           }
         }
+      }
+      if (props.onComplete) {
+        props.onComplete();
       }
     }
   }, []);

--- a/manifest-editor/src/shell/Universal/UniversalCopyPaste.types.ts
+++ b/manifest-editor/src/shell/Universal/UniversalCopyPaste.types.ts
@@ -1,6 +1,5 @@
 import { ReactNode } from "react";
 import { Reference } from "@iiif/presentation-3";
-import { StyledComponent } from "styled-components";
 import * as React from "react";
 
 export interface UniversalCopyPasteProps<T> {
@@ -11,4 +10,6 @@ export interface UniversalCopyPasteProps<T> {
   onDropReference?: (reference: Reference, e: DragEvent) => void;
   onPasteLink?: (link: string) => void;
   onPasteAnalysis?: (analysisResults: any) => void;
+  onLoading?: () => void;
+  onComplete?: () => void;
 }

--- a/manifest-editor/src/shell/Universal/UniversalCopyPaste.types.ts
+++ b/manifest-editor/src/shell/Universal/UniversalCopyPaste.types.ts
@@ -1,0 +1,14 @@
+import { ReactNode } from "react";
+import { Reference } from "@iiif/presentation-3";
+import { StyledComponent } from "styled-components";
+import * as React from "react";
+
+export interface UniversalCopyPasteProps<T> {
+  as?: keyof JSX.IntrinsicElements | React.ComponentType<T>;
+  children?: ReactNode;
+  reference?: Reference;
+  onPasteReference?: (reference: Reference) => void;
+  onDropReference?: (reference: Reference, e: DragEvent) => void;
+  onPasteLink?: (link: string) => void;
+  onPasteAnalysis?: (analysisResults: any) => void;
+}

--- a/manifest-editor/src/themes/tokens.ts
+++ b/manifest-editor/src/themes/tokens.ts
@@ -1,0 +1,2 @@
+export const mainColor = (props: any) => props.theme.color.main || "#347cff";
+export const lightgrey = (props: any) => props.theme.color.lightgrey;

--- a/manifest-editor/src/types/resource-editor-config.ts
+++ b/manifest-editor/src/types/resource-editor-config.ts
@@ -1,0 +1,1 @@
+export type ResourceEditorConfig<T = any> = [string, T] | string;


### PR DESCRIPTION
* Added canvas list view
* Added range navigation
* Made grid view filterable to a subset of canvases
    * Disabled reordering when a subset
* Universal copy and paste
    * Demo application
* Split out creation/building to functions
* Small optimisation in grid list (`useManifest` -> `useResourceContext`)
* Added read-only canvas ID to canvas technical properties
* Modular panel sizing/overflow fixes

### Still todo
- [ ] Icons or strategy for new views
- [ ] Fix drag/drop events for universal copy/paste component