### PR TITLE
Various bugs for canvas editing

### DIFF
--- a/packages/components/src/Sidebar.tsx
+++ b/packages/components/src/Sidebar.tsx
@@ -14,7 +14,9 @@ export function SidebarContent({
   className?: string;
   padding?: boolean;
 }) {
-  return <div className={cn("flex-1 min-h-0 overflow-y-auto", className, padding && "p-3")}>{children}</div>;
+  return (
+    <div className={cn("flex-1 min-h-0 overflow-y-auto pb-64", className, padding && "px-3 pt-3")}>{children}</div>
+  );
 }
 
 interface SidebarHeaderProps {

--- a/packages/creators/src/AnnotationPage/EmptyAnnotationPage/index.tsx
+++ b/packages/creators/src/AnnotationPage/EmptyAnnotationPage/index.tsx
@@ -1,3 +1,4 @@
+import { InternationalString } from "@iiif/presentation-3";
 import { CreatorDefinition, CreatorFunctionContext } from "@manifest-editor/creator-api";
 import { ThumbnailStripIcon } from "@manifest-editor/ui/icons/ThumbnailStripIcon";
 
@@ -19,9 +20,10 @@ export const emptyAnnotationPage: CreatorDefinition = {
   },
 };
 
-async function createEmptyAnnotationPage(data: unknown, ctx: CreatorFunctionContext) {
+async function createEmptyAnnotationPage(data: { label?: InternationalString }, ctx: CreatorFunctionContext) {
   return ctx.embed({
     id: ctx.generateId("annotations"),
+    label: data.label,
     type: "AnnotationPage",
     items: [],
   });

--- a/packages/editors/src/components/CanvasPanelEditor/CanvasPanelEditor.tsx
+++ b/packages/editors/src/components/CanvasPanelEditor/CanvasPanelEditor.tsx
@@ -1,10 +1,12 @@
 import { useLayoutActions } from "@manifest-editor/shell";
 import { EmptyState } from "@manifest-editor/ui/madoc/components/EmptyState";
-import { useVaultSelector, CanvasContext, useVault } from "react-iiif-vault";
+import { CanvasContext, useVault, useVaultSelector } from "react-iiif-vault";
 import { useInStack } from "../../helpers";
 import { CanvasPanelViewer } from "../CanvasPanelViewer/CanvasPanelViewer";
 
-export function CanvasPanelEditor() {
+export function CanvasPanelEditor({
+  asFallback = false,
+}: { asFallback?: boolean }) {
   const { edit, create } = useLayoutActions();
   const canvas = useInStack("Canvas");
   const annotationPage = useInStack("AnnotationPage");
@@ -14,7 +16,10 @@ export function CanvasPanelEditor() {
   const canvasId = canvas?.resource.source.id;
   let createAnnotation = undefined;
   const annotationPageId =
-    annotationPage && canvas && annotationPage.parent?.id === canvasId && annotationPage.property === "annotations"
+    annotationPage &&
+    canvas &&
+    annotationPage.parent?.id === canvasId &&
+    annotationPage.property === "annotations"
       ? annotationPage.resource.source.id
       : undefined;
 
@@ -34,7 +39,7 @@ export function CanvasPanelEditor() {
       }
       return 0;
     },
-    [canvasId]
+    [canvasId],
   );
 
   if (annotationPageId) {
@@ -62,9 +67,12 @@ export function CanvasPanelEditor() {
     return (
       <CanvasContext canvas={canvasId}>
         <CanvasPanelViewer
+          asFallback={asFallback}
           key={`${canvasId}/${totalAnnotations}/${annotationPageId}`}
           highlightAnnotation={annotationId}
-          onEditAnnotation={(id: string) => id !== annotationId && edit({ id, type: "Annotation" })}
+          onEditAnnotation={(id: string) =>
+            id !== annotationId && edit({ id, type: "Annotation" })
+          }
           createAnnotation={createAnnotation}
         />
       </CanvasContext>

--- a/packages/editors/src/components/CanvasPanelViewer/components/AdditionalContextBridge.tsx
+++ b/packages/editors/src/components/CanvasPanelViewer/components/AdditionalContextBridge.tsx
@@ -2,6 +2,7 @@ import { ModeContext } from "@atlas-viewer/atlas";
 import {
   AtlasStoreReactContext,
   LayoutStateReactContext,
+  ResourceEditingReactContext,
 } from "@manifest-editor/shell";
 import { useMemo } from "react";
 import {
@@ -18,6 +19,7 @@ export function AdditionalContextBridge(props: { children: React.ReactNode }) {
       mode: ModeContext,
       atlas: AtlasStoreReactContext,
       layout: LayoutStateReactContext,
+      resource: ResourceEditingReactContext,
     };
   }, []);
 
@@ -38,6 +40,7 @@ export function AdditionalContextBridgeInner(props: {
       mode: ModeContext,
       atlas: AtlasStoreReactContext,
       layout: LayoutStateReactContext,
+      resource: ResourceEditingReactContext,
     };
   }, []);
 

--- a/packages/editors/src/components/CanvasPanelViewer/components/NonAtlasStrategyRenderer.tsx
+++ b/packages/editors/src/components/CanvasPanelViewer/components/NonAtlasStrategyRenderer.tsx
@@ -1,15 +1,21 @@
 import { IIIFMediaPlayer } from "@manifest-editor/components";
 import { RenderTextualContent } from "@manifest-editor/components";
 import { useApp } from "@manifest-editor/shell";
-import { createContext, useContext, useMemo } from "react";
-import { useCanvas, useStrategy, useVault } from "react-iiif-vault";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+} from "react";
+import { useStrategy, useVault } from "react-iiif-vault";
 import { useInStack } from "../../../helpers";
 
-const SelfContext = createContext<any>(null);
+const SelfContext = createContext<null | React.ReactNode>(null);
 
 export function NonAtlasStrategyRenderer({
   children,
-}: { children: React.ReactNode }) {
+}: { children: React.ReactNode; deps?: any[] }) {
   const vault = useVault();
   const strategy = useStrategy();
   const canvas = useInStack("Canvas");
@@ -27,7 +33,7 @@ export function NonAtlasStrategyRenderer({
         }
       }
     }
-  }, [canvas, strategy]);
+  }, [canvas, strategy, vault, app.layout.canvasEditors]);
 
   if (!canvas) {
     return null;

--- a/packages/editors/src/helpers/editing-mode.ts
+++ b/packages/editors/src/helpers/editing-mode.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface EditingMode {
+  editMode: boolean;
+  setIsEditing: (isEditing: boolean) => void;
+  toggleEditMode: () => void;
+}
+
+export const useEditingMode = create<EditingMode>((set) => ({
+  editMode: false,
+  setIsEditing: (editMode: boolean) => set({ editMode }),
+  toggleEditMode: () => set((state) => ({ editMode: !state.editMode })),
+}));

--- a/packages/shell/src/BaseEditor/index.tsx
+++ b/packages/shell/src/BaseEditor/index.tsx
@@ -1,11 +1,17 @@
-import { LayoutPanel } from "../Layout/Layout.types";
-import { BaseEditor, BaseEditorBackButton, BaseEditorCloseButton } from "./BaseEditor";
+import type { LayoutPanel } from "../Layout/Layout.types";
+import {
+  BaseEditor,
+  BaseEditorBackButton,
+  BaseEditorCloseButton,
+} from "./BaseEditor";
 
 export const baseEditor: LayoutPanel = {
   id: "@manifest-editor/editor",
   label: "Editor",
   options: { hideHeader: true, tabs: true, minWidth: 400 },
-  renderBackAction: ({ backAction, fallback }) => <BaseEditorBackButton backAction={backAction} fallback={fallback} />,
+  renderBackAction: ({ backAction, fallback }) => (
+    <BaseEditorBackButton backAction={backAction} fallback={fallback} />
+  ),
   renderCloseAction: ({ closeAction, fallback }) => (
     <BaseEditorCloseButton closeAction={closeAction} fallback={fallback} />
   ),

--- a/packages/shell/src/ResourceEditingContext/ResourceEditingContext.tsx
+++ b/packages/shell/src/ResourceEditingContext/ResourceEditingContext.tsx
@@ -1,5 +1,5 @@
-import { Reference } from "@iiif/presentation-3";
-import { createContext, ReactNode, useContext, useMemo } from "react";
+import type { Reference } from "@iiif/presentation-3";
+import { createContext, type ReactNode, useContext, useMemo } from "react";
 import invariant from "tiny-invariant";
 import { useVault, useVaultSelector } from "react-iiif-vault";
 
@@ -7,9 +7,10 @@ interface ResourceEditingContext {
   resource: Reference<any> | null;
 }
 
-const ResourceEditingReactContext = createContext<ResourceEditingContext>({
-  resource: null,
-});
+export const ResourceEditingReactContext =
+  createContext<ResourceEditingContext>({
+    resource: null,
+  });
 
 export function useEditingContext() {
   return useContext(ResourceEditingReactContext);
@@ -62,7 +63,7 @@ export function ResourceEditingProvider({
           // Current resource.
           resource: id && type ? { id, type } : null,
         }),
-        [id, type]
+        [id, type],
       )}
     >
       {children}

--- a/packages/ui/components/organisms/Annotation/AnnotationTarget.tsx
+++ b/packages/ui/components/organisms/Annotation/AnnotationTarget.tsx
@@ -2,7 +2,10 @@ import { useEffect, useState } from "react";
 import { useCanvas, useVault } from "react-iiif-vault";
 import { LightBox } from "../../../atoms/LightBox";
 import { CheckboxInput, Input, InputLabel } from "../../../editors/Input";
-import { FlexContainerColumn, FlexContainerRow } from "../../layout/FlexContainer";
+import {
+  FlexContainerColumn,
+  FlexContainerRow,
+} from "../../layout/FlexContainer";
 import { Accordian } from "../Accordian/Accordian";
 
 type Target = {
@@ -10,8 +13,13 @@ type Target = {
   annotationID: string;
 };
 
-export const CanvasTargetEditor: React.FC<Target> = ({ canvasTarget, annotationID }) => {
-  const [target, setTarget] = useState<string[]>(canvasTarget.split("#xywh=")[1].split(","));
+export const CanvasTargetEditor: React.FC<Target> = ({
+  canvasTarget,
+  annotationID,
+}) => {
+  const [target, setTarget] = useState<string[]>(
+    canvasTarget.split("#xywh=")[1].split(","),
+  );
   const canvas = canvasTarget.split("#xywh=")[0];
 
   const vault = useVault();
@@ -79,7 +87,8 @@ export function AnnotationTarget({ canvasTarget, annotationID }: Target) {
   const isWhole =
     canvasTarget.includes("#xywh=") &&
     canvasTarget.split("#xywh=")[1] &&
-    canvasTarget.split("#xywh=")[1] === `0,0,${canvas?.width},${canvas?.height}`;
+    canvasTarget.split("#xywh=")[1] ===
+      `0,0,${canvas?.width},${canvas?.height}`;
 
   function changeToFullCanvas() {
     if (!canvas || !canvas.id) return;
@@ -101,11 +110,16 @@ export function AnnotationTarget({ canvasTarget, annotationID }: Target) {
           Target whole canvas
         </InputLabel>
         {!(isWhole || targetNotSpecified || showEditor) && (
-          <CanvasTargetEditor canvasTarget={canvasTarget} annotationID={annotationID} />
+          <CanvasTargetEditor
+            canvasTarget={canvasTarget}
+            annotationID={annotationID}
+          />
         )}
         {showEditor && (
           <CanvasTargetEditor
-            canvasTarget={canvasTarget + `#xywh=0,0,${canvas?.width},${canvas?.height}`}
+            canvasTarget={
+              canvasTarget + `#xywh=0,0,${canvas?.width},${canvas?.height}`
+            }
             annotationID={annotationID}
           />
         )}

--- a/packages/ui/ui/ViewControls/ViewControls.tsx
+++ b/packages/ui/ui/ViewControls/ViewControls.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from "styled-components";
 import { useViewerPreset } from "react-iiif-vault";
-import { CSSProperties } from "react";
+import type { CSSProperties } from "react";
 import { EditIcon } from "../../icons/EditIcon";
 import { CropIcon } from "../../icons/CropIcon";
 import { HomeIcon } from "../../icons/HomeIcon";
@@ -95,13 +95,21 @@ export function ViewControls({
   return (
     <CanvasViewerControls style={style}>
       {toggleCreateAnnotation && !editMode ? (
-        <CanvasViewerButton data-control="create" onClick={toggleCreateAnnotation} $active={creatingAnnotation}>
+        <CanvasViewerButton
+          data-control="create"
+          onClick={toggleCreateAnnotation}
+          $active={creatingAnnotation}
+        >
           {!createMode ? "Create annotation" : "Clear"}
         </CanvasViewerButton>
       ) : null}
       {toggleEditMode ? (
         <>
-          <CanvasViewerButton data-control="edit" onClick={toggleEditMode} $active={editMode}>
+          <CanvasViewerButton
+            data-control="edit"
+            onClick={toggleEditMode}
+            $active={editMode}
+          >
             {editMode ? (
               "Finish editing"
             ) : editIcon ? (
@@ -111,7 +119,10 @@ export function ViewControls({
             )}
           </CanvasViewerButton>
           {clearSelection && editMode ? (
-            <CanvasViewerButton data-control="edit-clear" onClick={clearSelection}>
+            <CanvasViewerButton
+              data-control="edit-clear"
+              onClick={clearSelection}
+            >
               Clear
             </CanvasViewerButton>
           ) : null}
@@ -122,22 +133,39 @@ export function ViewControls({
           <RefreshIcon title={"Refresh viewer"} />
         </CanvasViewerButton>
       ) : null}
-      <CanvasViewerButton data-control="home" onClick={() => preset?.runtime.world.goHome()}>
+      <CanvasViewerButton
+        data-control="home"
+        onClick={() => preset?.runtime.world.goHome()}
+      >
         <HomeIcon title={"Home"} />
       </CanvasViewerButton>
-      <CanvasViewerButton data-control="zoom-out" onClick={() => preset?.runtime.world.zoomTo(1 / 0.75)}>
+      <CanvasViewerButton
+        data-control="zoom-out"
+        onClick={() => preset?.runtime.world.zoomTo(1 / 0.75)}
+      >
         <MinusIcon title={"Zoom out"} />
       </CanvasViewerButton>
-      <CanvasViewerButton data-control="zoom-in" onClick={() => preset?.runtime.world.zoomTo(0.75)}>
+      <CanvasViewerButton
+        data-control="zoom-in"
+        onClick={() => preset?.runtime.world.zoomTo(0.75)}
+      >
         <PlusIcon title={"Zoom in"} />
       </CanvasViewerButton>
 
       {enableNavigation ? (
         <>
-          <CanvasViewerButton data-control="previous" disabled={!onPrevious} onClick={onPrevious}>
+          <CanvasViewerButton
+            data-control="previous"
+            disabled={!onPrevious}
+            onClick={onPrevious}
+          >
             <BackIcon />
           </CanvasViewerButton>
-          <CanvasViewerButton data-control="next" disabled={!onNext} onClick={onNext}>
+          <CanvasViewerButton
+            data-control="next"
+            disabled={!onNext}
+            onClick={onNext}
+          >
             <BackIcon style={{ transform: "rotate(180deg)" }} />
           </CanvasViewerButton>
         </>

--- a/presets/exhibition-preset/src/canvas-editors/image-block-editor.tsx
+++ b/presets/exhibition-preset/src/canvas-editors/image-block-editor.tsx
@@ -75,7 +75,7 @@ export function ImageBlockEditor({
         </div>
       ) : (
         <div className="h-full flex flex-1 min-h-0">
-          <CanvasPanelEditor />
+          <CanvasPanelEditor asFallback />
         </div>
       )}
     </CanvasContext>
@@ -97,7 +97,7 @@ function ImageBlockRenderer() {
       )}
     >
       <div className="flex-1 h-full flex min-w-0">
-        <CanvasPanelEditor />
+        <CanvasPanelEditor asFallback />
       </div>
       {!isImage ? (
         <div

--- a/presets/exhibition-preset/src/components/ExhibitionItemConversion.tsx
+++ b/presets/exhibition-preset/src/components/ExhibitionItemConversion.tsx
@@ -1,0 +1,36 @@
+import { getValue } from "@iiif/helpers";
+import { ActionButton } from "@manifest-editor/components";
+import { useEditor } from "@manifest-editor/shell";
+
+export function ExhibitionItemConversion() {
+  const editor = useEditor();
+
+  const applyDefaultSettings = () => {
+    const canvasWidth = editor.technical.width.get();
+    const canvasHeight = editor.technical.height.get();
+    const summary = editor.descriptive.summary;
+    const behaviors = editor.technical.behavior;
+
+    const behaviorsToAdd = behaviors.get();
+    behaviorsToAdd.push("w-12");
+
+    const height = Math.max(1, Math.min(12, Math.round((canvasWidth / canvasHeight) * 12)));
+    behaviorsToAdd.push(`h-${height}`);
+    // Implementation of applying default settings
+    // 1. Add behavior of "w-12"
+    // 2. Add behavior of "h-1" to "h-12" based on canvas height
+    // 3. Add an empty summary
+    if (!getValue(summary.get())) {
+      summary.set({ en: ["Summary of image"] });
+    }
+
+    editor.technical.behavior.set(behaviorsToAdd);
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-4 border-me-100 border-2 p-4 rounded">
+      This canvas was not created in the exhibition editor. Do you want to apply default settings?
+      <ActionButton onPress={() => applyDefaultSettings()}>Apply defaults</ActionButton>
+    </div>
+  );
+}

--- a/presets/exhibition-preset/src/helpers.ts
+++ b/presets/exhibition-preset/src/helpers.ts
@@ -1,3 +1,5 @@
+import { CanvasNormalized } from "@iiif/presentation-3-normalized";
+
 const heightMap = {
   "h-1": "lg:min-h-[100px] row-span-1",
   "h-2": "lg:min-h-[200px] row-span-2",
@@ -93,8 +95,7 @@ export function getGridStats(behavior?: string[]) {
   const isBottom = behavior?.includes("bottom");
   const isTop = behavior?.includes("top");
   const isInfo = behavior?.includes("info");
-  const isImage =
-    behavior?.includes("image") || (!isLeft && !isRight && !isBottom && !isTop);
+  const isImage = behavior?.includes("image") || (!isLeft && !isRight && !isBottom && !isTop);
 
   return {
     isRight,
@@ -104,4 +105,21 @@ export function getGridStats(behavior?: string[]) {
     isInfo,
     isImage,
   };
+}
+
+export function isExhibitionItem(canvas: CanvasNormalized | undefined) {
+  if (!canvas) return false;
+
+  const behaviors = canvas.behavior || [];
+  if (behaviors.includes("image") || behaviors.includes("info")) {
+    return true;
+  }
+
+  for (const behavior of behaviors) {
+    if (behavior.startsWith("w-") || behavior.startsWith("h-")) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/presets/exhibition-preset/src/index.tsx
+++ b/presets/exhibition-preset/src/index.tsx
@@ -14,7 +14,7 @@ import {
 import { infoBoxCreator } from "./creators/info-box-creator";
 import { youtubeSlideCreator } from "./creators/youtube-slide-creator";
 import { exhibitionGridLeftPanel } from "./left-panels/ExhibitionGrid";
-import { customBehaviourEditor } from "./left-panels/SlideBehaviours";
+import { customBehaviourEditor } from "./right-panels/SlideBehaviours";
 import { exhibitionCanvasEditor } from "./right-panels/ExhibitionCanvasEditor";
 import { exhibitionSummaryEdtior } from "./right-panels/ExhibitionSummaryEditor";
 import { exhibitionTourSteps } from "./right-panels/ExhibitionTourSteps";
@@ -59,12 +59,7 @@ export const exhibitionEditorPreset = extendApp(
       youtubeMainEdtior,
       infoBlockEditor,
     ],
-    editors: [
-      exhibitionCanvasEditor,
-      customBehaviourEditor,
-      exhibitionSummaryEdtior,
-      exhibitionTourSteps,
-    ],
+    editors: [exhibitionCanvasEditor, customBehaviourEditor, exhibitionSummaryEdtior, exhibitionTourSteps],
     creators: [
       infoBoxCreator,
       imageSlideBottomCreator,
@@ -73,5 +68,5 @@ export const exhibitionEditorPreset = extendApp(
       imageSlideRightCreator,
       youtubeSlideCreator,
     ],
-  },
+  }
 );

--- a/presets/exhibition-preset/src/right-panels/ExhibitionCanvasEditor.tsx
+++ b/presets/exhibition-preset/src/right-panels/ExhibitionCanvasEditor.tsx
@@ -7,15 +7,11 @@ import {
   PaintingAnnotationList,
   createAppActions,
 } from "@manifest-editor/editors";
-import {
-  type EditorDefinition,
-  ResourceEditingProvider,
-  useEditingResource,
-  useEditor,
-} from "@manifest-editor/shell";
+import { type EditorDefinition, ResourceEditingProvider, useEditingResource, useEditor } from "@manifest-editor/shell";
 import { AnnotationPageContext, useCanvas } from "react-iiif-vault";
 import { AspectRatioWarning } from "../components/AspectRatioWarning";
-import { getGridStats } from "../helpers";
+import { getGridStats, isExhibitionItem } from "../helpers";
+import { ExhibitionItemConversion } from "../components/ExhibitionItemConversion";
 
 export const exhibitionCanvasEditor: EditorDefinition = {
   id: "@exhibition/right-panel-editor",
@@ -47,29 +43,17 @@ function ExhibitionRightPanel() {
   const pages = items.get();
   const page = pages[0];
 
-  if (!canvas || !page || !resource) return null;
+  const isAnExhibitionCanvas = isExhibitionItem(canvas);
+
+  if (!canvas || !page || !resource) return <div className="p-8">Canvas, page, or resource not found</div>;
 
   return (
     <Sidebar>
       <SidebarContent padding>
         <ResourceEditingProvider resource={canvas}>
-          <LanguageMapEditor dispatchType="label" disableMultiline />
+          {!isAnExhibitionCanvas ? <ExhibitionItemConversion /> : null}
 
-          <div>
-            <InputContainer $wide>
-              <DimensionsTriplet
-                widthId={width.containerId()}
-                width={width.get() || 0}
-                changeWidth={(v) => width.set(v)}
-                heightId={height.containerId()}
-                height={height.get() || 0}
-                changeHeight={(v) => height.set(v)}
-              />
-              <div>
-                <AspectRatioWarning />
-              </div>
-            </InputContainer>
-          </div>
+          <LanguageMapEditor dispatchType="label" disableMultiline />
 
           <LinkingPropertyList
             containerId={thumbnail.containerId()}

--- a/presets/exhibition-preset/src/right-panels/ExhibitionSummaryEditor.tsx
+++ b/presets/exhibition-preset/src/right-panels/ExhibitionSummaryEditor.tsx
@@ -1,9 +1,6 @@
 import { Sidebar, SidebarContent } from "@manifest-editor/components";
 import { LanguageMapEditor } from "@manifest-editor/editors";
-import {
-  type EditorDefinition,
-  ResourceEditingProvider,
-} from "@manifest-editor/shell";
+import { type EditorDefinition, ResourceEditingProvider } from "@manifest-editor/shell";
 import { useCanvas } from "react-iiif-vault";
 import { getGridStats } from "../helpers";
 
@@ -35,6 +32,7 @@ function ExhibitionRightPanel() {
     <Sidebar>
       <SidebarContent padding>
         <ResourceEditingProvider resource={canvas}>
+          <LanguageMapEditor dispatchType="label" />
           <LanguageMapEditor dispatchType="summary" />
         </ResourceEditingProvider>
       </SidebarContent>

--- a/presets/exhibition-preset/src/right-panels/ExhibitionTourSteps.tsx
+++ b/presets/exhibition-preset/src/right-panels/ExhibitionTourSteps.tsx
@@ -41,10 +41,51 @@ function ExhibitionRightPanelOptionalPage() {
 
   // @todo create annotation page?
   if (!firstAnnotationPage || !canvas || !itemsAnnotationPage) {
-    return <div className="p-4 opacity-50 text-center">Tour not available</div>;
+    return <PromptCreationOfTourSteps />;
   }
 
   return <ExhibitionRightPanel />;
+}
+
+function PromptCreationOfTourSteps() {
+  const canvas = useCanvas();
+  const creator = useInlineCreator();
+
+  const createEmptyAnnotationPage = () => {
+    if (!canvas) return;
+    creator.create(
+      "@manifest-editor/empty-annotation-page",
+      {
+        label: { en: ["Tour steps"] },
+      },
+      {
+        target: {
+          id: canvas.id,
+          type: "Canvas",
+        },
+        targetType: "AnnotationPage",
+        parent: {
+          property: "items",
+          resource: {
+            id: canvas.id,
+            type: "Canvas",
+          },
+        },
+      }
+    );
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center p-4">
+      <div className="p-4 opacity-50 text-center">This image does not yet have a tour.</div>
+      <Button
+        className="border w-full disabled:opacity-50 border-gray-300 hover:border-me-500 hover:bg-me-50 cursor-pointer shadow-sm rounded p-4 bg-white relative text-black/40 hover:text-me-500"
+        onPress={createEmptyAnnotationPage}
+      >
+        Create Tour
+      </Button>
+    </div>
+  );
 }
 
 function ExhibitionRightPanel() {

--- a/presets/exhibition-preset/src/right-panels/SlideBehaviours.tsx
+++ b/presets/exhibition-preset/src/right-panels/SlideBehaviours.tsx
@@ -1,15 +1,14 @@
-import {
-  Sidebar,
-  SidebarContent,
-  SidebarHeader,
-} from "@manifest-editor/components";
+import { Sidebar, SidebarContent, SidebarHeader } from "@manifest-editor/components";
 import {
   BehaviorEditor,
   type BehaviorEditorProps,
+  DimensionsTriplet,
+  InputContainer,
   useInStack,
 } from "@manifest-editor/editors";
 import { type EditorDefinition, useEditor } from "@manifest-editor/shell";
 import { useState } from "react";
+import { AspectRatioWarning } from "../components/AspectRatioWarning";
 
 export const customBehaviourEditor: EditorDefinition = {
   component: () => <SlideBehavioursPanel />,
@@ -52,9 +51,7 @@ const exhibitionConfigs: BehaviorEditorProps["configs"] = [
   },
   {
     id: "size",
-    component: (existing, setBehaviors) => (
-      <EditSize behaviors={existing} setBehaviors={setBehaviors} />
-    ),
+    component: (existing, setBehaviors) => <EditSize behaviors={existing} setBehaviors={setBehaviors} />,
     label: { en: ["Size"] },
     type: "custom",
     initialOpen: true,
@@ -80,10 +77,7 @@ function parseBehaviors(items: string[]) {
   };
 }
 
-function EditSize({
-  behaviors,
-  setBehaviors,
-}: { behaviors: string[]; setBehaviors: (behaviors: string[]) => void }) {
+function EditSize({ behaviors, setBehaviors }: { behaviors: string[]; setBehaviors: (behaviors: string[]) => void }) {
   const { width, height } = parseBehaviors(behaviors);
   const [hoverPosition, setHoverPosition] = useState({ x: -1, y: -1 });
 
@@ -129,10 +123,7 @@ function EditSize({
   });
 
   return (
-    <div
-      className="grid grid-cols-12 grid-rows-12 gap-1"
-      onMouseLeave={() => setHoverPosition({ x: -1, y: -1 })}
-    >
+    <div className="grid grid-cols-12 grid-rows-12 gap-1" onMouseLeave={() => setHoverPosition({ x: -1, y: -1 })}>
       {cells}
     </div>
   );
@@ -141,6 +132,7 @@ function EditSize({
 function SlideBehavioursPanel() {
   const canvas = useInStack("Canvas");
   const editor = useEditor();
+  const { width, height } = editor.technical;
 
   if (!canvas || editor.technical.type !== "Canvas") {
     return (
@@ -154,6 +146,22 @@ function SlideBehavioursPanel() {
   return (
     <Sidebar>
       <SidebarContent>
+        <div className="px-2">
+          <InputContainer $wide>
+            <DimensionsTriplet
+              widthId={width.containerId()}
+              width={width.get() || 0}
+              changeWidth={(v) => width.set(v)}
+              heightId={height.containerId()}
+              height={height.get() || 0}
+              changeHeight={(v) => height.set(v)}
+            />
+            <div>
+              <AspectRatioWarning />
+            </div>
+          </InputContainer>
+        </div>
+
         <BehaviorEditor
           behavior={editor.technical.behavior.get() || []}
           onChange={(v) => {


### PR DESCRIPTION
- Fixed editing exhibition media targets
- Fixed tabs being deselected when editing resources
- Added cancel/save changes button when editing or adding tour steps
- Ability to add tour steps when there is no annotation page
<img width="408" alt="image" src="https://github.com/user-attachments/assets/9317b772-7080-47bc-86ce-e0f76c0ebd46" />

- Missing properties on exhibition:
<img width="424" alt="image" src="https://github.com/user-attachments/assets/c78fc40b-f1eb-4316-8ddc-2b801c0bf671" />
