### PR TITLE
aria-label on sidebar buttons

### DIFF
--- a/packages/components/src/PanelSideMenuItem.tsx
+++ b/packages/components/src/PanelSideMenuItem.tsx
@@ -19,6 +19,7 @@ export function PanelSideMenuItem(props: PanelSideMenuItemProps) {
               ? "bg-me-primary-500 hover:bg-me-primary-600 hover:text-white text-white"
               : "text-me-gray-700"
           )}
+          aria-label={props.label}
           onMouseDown={props.onClick}
         >
           {props.icon}


### PR DESCRIPTION
Sidebar buttons have no role / aria-label / text etc that allows them to be easily located in tests.

PR adds `aria-label` (untested)

BEFORE:
![image](https://github.com/user-attachments/assets/f1e7e987-1a95-4e0f-8045-e7dc4a65ecdc)
