### PR TITLE
Updated creator definition to use typed api to make presets quicker

### DIFF
--- a/apps/web/src/components/browser-editor/BrowserEditor.tsx
+++ b/apps/web/src/components/browser-editor/BrowserEditor.tsx
@@ -44,7 +44,6 @@ import "@manifest-editor/shell/dist/index.css";
 import "@manifest-editor/components/dist/index.css";
 import "@manifest-editor/exhibition-preset/dist/index.css";
 import { createThumbnailHelper } from "@iiif/helpers";
-import type { CreatorDefinition } from "@manifest-editor/creator-api";
 import { useInStack } from "@manifest-editor/editors";
 import { useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";

--- a/packages/creator-api/src/Creator.ts
+++ b/packages/creator-api/src/Creator.ts
@@ -1,8 +1,8 @@
-import { Reference } from "@iiif/presentation-3";
 import { Vault } from "@iiif/helpers/vault";
-import { CreatorRuntime } from "./CreatorRuntime";
-import { CreatableResource, CreatorDefinition, CreatorOptions } from "./types";
 import { entityActions } from "@iiif/helpers/vault/actions";
+import type { Reference } from "@iiif/presentation-3";
+import { CreatorRuntime } from "./CreatorRuntime";
+import type { CreatableResource, CreatorDefinition, CreatorOptions } from "./types";
 import { matchBasedOnResource } from "./utils";
 
 export class Creator {
@@ -17,11 +17,7 @@ export class Creator {
   }
 
   matchBasedOnResource(resource: CreatableResource) {
-    return matchBasedOnResource(
-      resource,
-      this.configs || [],
-      { vault: this.vault },
-    );
+    return matchBasedOnResource(resource, this.configs || [], { vault: this.vault });
   }
 
   async create(definition: string, payload: any, options?: Partial<CreatorOptions>): Promise<Reference> {
@@ -46,7 +42,7 @@ export class Creator {
         const type = foundDefinition.supports.parentFieldMap[options.parent.resource.type];
         if (!type || !type.includes(options.parent.property)) {
           throw new Error(
-            `Definition ${definition} does not support parent ${options.parent.property} / ${options.parent.property}`
+            `Definition ${definition} does not support parent ${options.parent.property} / ${options.parent.property}`,
           );
         }
       }
@@ -71,7 +67,7 @@ export class Creator {
             type: options.parent.resource.type as any,
             value: resource.ref(),
             key: options.parent.property,
-          })
+          }),
         );
       } else {
         afterActions.push(
@@ -81,7 +77,7 @@ export class Creator {
             reference: resource.ref(),
             key: options.parent.property,
             index: options.parent.atIndex,
-          })
+          }),
         );
       }
     }

--- a/packages/creator-api/src/CreatorInstance.ts
+++ b/packages/creator-api/src/CreatorInstance.ts
@@ -1,10 +1,17 @@
-import { Vault } from "@iiif/helpers/vault";
-import { CreatorDefinition, CreatorFunctionContext, CreatorOptions } from "./types";
-import { Reference, SpecificResource } from "@iiif/presentation-3";
+import type { Vault } from "@iiif/helpers/vault";
+import type { Reference, SpecificResource } from "@iiif/presentation-3";
+import type { InputShape } from "polygon-editor";
 import { CreatorResource } from "./CreatorResource";
 import { CreatorRuntime } from "./CreatorRuntime";
 import { ReferencedResource } from "./ReferencedResource";
-import { InputShape } from "polygon-editor";
+import type { CreatorDefinitionFilterByParent, ExtractCreatorGenerics, IIIFManifestEditor } from "./creator-register";
+import type {
+  AllAvailableParentTypes,
+  CreatorDefinition,
+  CreatorFunctionContext,
+  CreatorOptions,
+  GetSupportedResourceFields,
+} from "./types";
 import { randomId } from "./utils";
 
 export class CreatorInstance implements CreatorFunctionContext {

--- a/packages/creator-api/src/CreatorResource.ts
+++ b/packages/creator-api/src/CreatorResource.ts
@@ -1,9 +1,9 @@
+import type { Vault } from "@iiif/helpers/vault";
+import { HAS_PART, PART_OF } from "@iiif/parser";
+import type { SpecificResource } from "@iiif/presentation-3";
 import { references } from "@manifest-editor/editor-api";
-import { Vault } from "@iiif/helpers/vault";
 import { ReferencedResource } from "./ReferencedResource";
 import { getEmptyType, resolveType } from "./utils";
-import { HAS_PART, PART_OF } from "@iiif/parser";
-import { SpecificResource } from "@iiif/presentation-3";
 
 export class CreatorResource {
   resource: any;
@@ -29,7 +29,7 @@ export class CreatorResource {
 
     for (const key of properties) {
       // These properties are NOT references and can be just included normally.
-      if (references.inlineProperties.includes(key) || !references.all.includes(key)) {
+      if (references.inlineProperties.includes(key as any) || !references.all.includes(key as any)) {
         continue;
       }
 
@@ -45,7 +45,6 @@ export class CreatorResource {
           const rangeRef = new ReferencedResource(range, vault);
           newRange.push(rangeRef);
           data[key] = rangeRef;
-          continue;
         }
         data[key] = newRange;
         continue;
@@ -82,12 +81,12 @@ export class CreatorResource {
       }
 
       // @todo Handle single item cases. (not caught by the above 2 cases)
-      if (references.single.includes(key)) {
+      if (references.single.includes(key as any)) {
         continue;
       }
 
       // This property SHOULD already be in the Vault OR an instance of creator resource.
-      if (references.externalProperties.includes(key) || references.internalProperties.includes(key)) {
+      if (references.externalProperties.includes(key as any) || references.internalProperties.includes(key as any)) {
         const _items = (data[key] || []) as any[];
         const items = Array.isArray(_items) ? _items : [_items];
         const newItems: any[] = [];
@@ -154,12 +153,12 @@ export class CreatorResource {
 
     for (const key of properties) {
       // Skip these, they are just normal inline values.
-      if (references.inlineProperties.includes(key) || !references.all.includes(key)) {
+      if (references.inlineProperties.includes(key as any) || !references.all.includes(key as any)) {
         newResource[key] = resource[key];
         continue;
       }
 
-      if (references.single.includes(key)) {
+      if (references.single.includes(key as any)) {
         const ref = resource[key];
         if (ref instanceof ReferencedResource) {
           // These MUST be specific resources.

--- a/packages/creator-api/src/CreatorRuntime.ts
+++ b/packages/creator-api/src/CreatorRuntime.ts
@@ -1,9 +1,9 @@
-import { Reference } from "@iiif/presentation-3";
-import { Vault } from "@iiif/helpers/vault";
-import { importEntities, addMappings, batchActions } from "@iiif/helpers/vault/actions";
+import type { Vault } from "@iiif/helpers/vault";
+import { addMappings, batchActions, importEntities } from "@iiif/helpers/vault/actions";
+import type { Reference } from "@iiif/presentation-3";
 import { CreatorInstance } from "./CreatorInstance";
 import { CreatorResource } from "./CreatorResource";
-import { CreatorDefinition, CreatorOptions } from "./types";
+import type { CreatorDefinition, CreatorOptions } from "./types";
 import { resolveType } from "./utils";
 
 export class CreatorRuntime {
@@ -22,7 +22,7 @@ export class CreatorRuntime {
     payload: any,
     createConfigs: CreatorDefinition[],
     previewVault: Vault,
-    options?: Partial<CreatorOptions>
+    options?: Partial<CreatorOptions>,
   ) {
     this.vault = vault;
     this.previewVault = previewVault;
@@ -30,7 +30,7 @@ export class CreatorRuntime {
     this.payload = payload;
     this.configs = createConfigs;
     this.options = {
-      targetType: (options || {}).targetType || definition.resourceType,
+      targetType: options?.targetType || definition.resourceType,
       ...(options || {}),
     };
   }

--- a/packages/creator-api/src/creator-register.ts
+++ b/packages/creator-api/src/creator-register.ts
@@ -1,6 +1,3 @@
-// types and helpers for the creator register.
-
-import type { InternationalString } from "@iiif/presentation-3";
 import type {
   AllAvailableParentTypes,
   AllParentTypes,
@@ -120,28 +117,6 @@ type HelperInArray<ToFind, Array extends readonly any[]> = Array extends readonl
     : HelperInArray<ToFind, Tail>
   : false;
 
-// type HelperInArray_test = HelperInArray<"ContentResource", ["ContentResource", "Manifest"]>;
-
-// type SupportsManifest = CreatorSupportsParentResourceType<typeof imageUrlCreator, "ContentResource">;
-
-// type FilterCreatorsByParentType<
-//   Creators extends Record<any, CreatorDefinition>,
-//   Type extends AllAvailableParentTypes,
-// > = {
-//   [K in keyof Creators as keyof Creators]: CreatorSupportsParentResourceType<Creators[K], Type> extends true
-//     ? Creators[K]["id"]
-//     : never;
-// }[keyof Creators];
-
-// type RecordToArray<Rec extends Record<any, any>> = {
-//   [K in keyof Rec]: Rec[K];
-// }[keyof Rec][];
-
-// type Values<T> = T[keyof T];
-// type CreatorDefinitionsArray = Array<Values<IIIFManifestEditor.CreatorDefinitions>>;
-
-// type AllIds = CreatorDefinitionsArray[number]["id"];
-
 export type CreatorDefinitionFilterByParent<
   Type extends AllAvailableParentTypes,
   Field extends AllProperties = AllProperties,
@@ -149,38 +124,3 @@ export type CreatorDefinitionFilterByParent<
 > = {
   [K in keyof CD]: CreatorSupportsParent<CD[K], Type, Field> extends true ? CD[K] : never;
 }[keyof CD];
-
-// type FilterCreatorsByParentType2<
-//   Creators extends Array<CreatorDefinition>,
-//   Type extends AllAvailableParentTypes,
-//   ReturnType extends Array<CreatorDefinition> = [],
-// > = Creators extends [infer Head extends CreatorDefinition, ...infer Tail extends Array<CreatorDefinition>]
-//   ? CreatorSupportsParentResourceType<Head, Type> extends true
-//     ? FilterCreatorsByParentType2<Tail, Type, [...ReturnType, Head]>
-//     : ReturnType
-//   : ReturnType;
-
-// type FirstCreator<
-//   Creators extends Array<CreatorDefinition>,
-//   Type extends AllAvailableParentTypes,
-//   ReturnType extends Array<CreatorDefinition> = [],
-// > = Creators extends [infer Head, ...infer Tail] ? Head : never;
-
-// type t2 = FilterCreatorsByParentType2<CreatorDefinitionsArray, "ContentResource">;
-
-// type t1 = typeof imageUrlCreator.additionalTypes;
-
-// // No we want functions that use the register.
-export function exampleFunction<
-  const ResourceType extends AllAvailableParentTypes,
-  const ResourceField extends GetSupportedResourceFields<ResourceType>,
-  const CID extends CreatorDefinitionFilterByParent<ResourceType, ResourceField>["id"],
->(
-  resourceType: ResourceType,
-  resourceField: ResourceField,
-  creator: CID,
-): (args: ExtractCreatorGenerics<IIIFManifestEditor.CreatorDefinitions[CID]>["Payload"]) => void {
-  // Implementation here
-  //
-  return () => {};
-}

--- a/packages/creator-api/src/creator-register.ts
+++ b/packages/creator-api/src/creator-register.ts
@@ -1,0 +1,186 @@
+// types and helpers for the creator register.
+
+import type { InternationalString } from "@iiif/presentation-3";
+import type {
+  AllAvailableParentTypes,
+  AllParentTypes,
+  AllProperties,
+  CreatorDefinition,
+  GetSupportedResourceFields,
+  SpecificCreatorDefinition,
+} from "./types";
+
+// Want to enable the following APIs.
+//
+// const createImage = useCreator(
+//   resource,
+//   "thumbnail",
+//   "@manifest-editor/image-url-creator"
+// );
+//
+// createImage({ url: 'https://example.org/image.jpg' });
+//
+// These should be constructed from an array of creators.
+// UseCreator<Resource, ResourceField, CreatorId> -> CreatorPayload
+//
+// But then also:
+// await manifestEditor.descriptive.thumbnail.create("@manifest-editor/image-url-creator", {
+//   url: "https://example.org/image.jpg",
+// });
+//
+// So essentially, I think we want to create a type that is roughly structured like this:
+// {
+//   Manifest: {
+//      thumbnail: {
+//        "@manifest-editor/image-url-creator": {
+//          url: string;
+//        }
+//      }
+//   }
+// }
+// Although it would include _all_ available creators.
+// Then the helpers would be fairly easy to implement.
+//
+// Here the creator definition (might need to change) for this:
+
+export function defineCreator<
+  const Payload = any,
+  const ID = Readonly<string>,
+  const ResourceType extends AllAvailableParentTypes = never,
+  const AdditionalResourceTypes extends Array<AllAvailableParentTypes> = [],
+  const AllResourceTypes = [ResourceType, ...AdditionalResourceTypes],
+  const SupportsParentTypes extends Array<AllAvailableParentTypes> = AllParentTypes,
+  const SupportsParentFields extends Array<AllProperties> = [],
+>(
+  options: SpecificCreatorDefinition<
+    Payload,
+    ID,
+    ResourceType,
+    AdditionalResourceTypes,
+    AllResourceTypes,
+    SupportsParentTypes,
+    SupportsParentFields
+  >,
+) {
+  return options;
+}
+
+export declare namespace IIIFManifestEditor {
+  // biome-ignore lint/suspicious/noEmptyInterface: Empty for global register.
+  interface CreatorDefinitions {}
+}
+
+export type ExtractCreatorGenerics<T extends CreatorDefinition> = T extends SpecificCreatorDefinition<
+  infer Payload,
+  infer ID,
+  infer ResourceType,
+  infer AdditionalResourceTypes,
+  infer AllResourceTypes,
+  infer SupportsParentTypes,
+  infer SupportsParentFields
+>
+  ? {
+      Payload: Payload;
+      ID: ID;
+      ResourceType: ResourceType;
+      AdditionalResourceTypes: AdditionalResourceTypes;
+      AllResourceTypes: AllResourceTypes;
+      SupportsParentTypes: SupportsParentTypes;
+      SupportsParentFields: SupportsParentFields;
+    }
+  : never;
+
+type CreatorSupportsParentTypes<T, Type extends AllAvailableParentTypes> = T extends CreatorDefinition
+  ? ExtractCreatorGenerics<T>["SupportsParentTypes"] extends never
+    ? false
+    : HelperInArray<Type, ExtractCreatorGenerics<T>["SupportsParentTypes"]>
+  : false;
+
+type CreatorSupportsParentFields<T, Field extends AllProperties> = T extends CreatorDefinition
+  ? ExtractCreatorGenerics<T>["SupportsParentFields"] extends never
+    ? false
+    : HelperInArray<Field, ExtractCreatorGenerics<T>["SupportsParentFields"]>
+  : false;
+
+type CreatorSupportsParent<
+  T,
+  Type extends AllAvailableParentTypes,
+  Field extends AllProperties,
+> = T extends CreatorDefinition
+  ? CreatorSupportsParentTypes<T, Type> extends true
+    ? CreatorSupportsParentFields<T, Field> extends true
+      ? true
+      : false
+    : false
+  : false;
+
+type HelperInArray<ToFind, Array extends readonly any[]> = Array extends readonly [infer Head, ...infer Tail]
+  ? Head extends ToFind
+    ? true
+    : HelperInArray<ToFind, Tail>
+  : false;
+
+// type HelperInArray_test = HelperInArray<"ContentResource", ["ContentResource", "Manifest"]>;
+
+// type SupportsManifest = CreatorSupportsParentResourceType<typeof imageUrlCreator, "ContentResource">;
+
+// type FilterCreatorsByParentType<
+//   Creators extends Record<any, CreatorDefinition>,
+//   Type extends AllAvailableParentTypes,
+// > = {
+//   [K in keyof Creators as keyof Creators]: CreatorSupportsParentResourceType<Creators[K], Type> extends true
+//     ? Creators[K]["id"]
+//     : never;
+// }[keyof Creators];
+
+// type RecordToArray<Rec extends Record<any, any>> = {
+//   [K in keyof Rec]: Rec[K];
+// }[keyof Rec][];
+
+// type Values<T> = T[keyof T];
+// type CreatorDefinitionsArray = Array<Values<IIIFManifestEditor.CreatorDefinitions>>;
+
+// type AllIds = CreatorDefinitionsArray[number]["id"];
+
+export type CreatorDefinitionFilterByParent<
+  Type extends AllAvailableParentTypes,
+  Field extends AllProperties = AllProperties,
+  CD extends IIIFManifestEditor.CreatorDefinitions = IIIFManifestEditor.CreatorDefinitions,
+> = {
+  [K in keyof CD]: CreatorSupportsParent<CD[K], Type, Field> extends true ? CD[K] : never;
+}[keyof CD];
+
+// type FilterCreatorsByParentType2<
+//   Creators extends Array<CreatorDefinition>,
+//   Type extends AllAvailableParentTypes,
+//   ReturnType extends Array<CreatorDefinition> = [],
+// > = Creators extends [infer Head extends CreatorDefinition, ...infer Tail extends Array<CreatorDefinition>]
+//   ? CreatorSupportsParentResourceType<Head, Type> extends true
+//     ? FilterCreatorsByParentType2<Tail, Type, [...ReturnType, Head]>
+//     : ReturnType
+//   : ReturnType;
+
+// type FirstCreator<
+//   Creators extends Array<CreatorDefinition>,
+//   Type extends AllAvailableParentTypes,
+//   ReturnType extends Array<CreatorDefinition> = [],
+// > = Creators extends [infer Head, ...infer Tail] ? Head : never;
+
+// type t2 = FilterCreatorsByParentType2<CreatorDefinitionsArray, "ContentResource">;
+
+// type t1 = typeof imageUrlCreator.additionalTypes;
+
+// // No we want functions that use the register.
+export function exampleFunction<
+  const ResourceType extends AllAvailableParentTypes,
+  const ResourceField extends GetSupportedResourceFields<ResourceType>,
+  const CID extends CreatorDefinitionFilterByParent<ResourceType, ResourceField>["id"],
+>(
+  resourceType: ResourceType,
+  resourceField: ResourceField,
+  creator: CID,
+): (args: ExtractCreatorGenerics<IIIFManifestEditor.CreatorDefinitions[CID]>["Payload"]) => void {
+  // Implementation here
+  //
+  return () => {};
+}

--- a/packages/creator-api/src/index.ts
+++ b/packages/creator-api/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./Creator";
 export * from "./types";
 export * from "./CreatorResource";
-export * from './utils';
+export * from "./utils";
+export * from "./creator-register";

--- a/packages/creator-api/src/types.ts
+++ b/packages/creator-api/src/types.ts
@@ -1,9 +1,20 @@
 import type { Vault } from "@iiif/helpers/vault";
-import type { Reference, SpecificResource } from "@iiif/presentation-3";
+import type {
+  Annotation,
+  DescriptiveProperties,
+  LinkingProperties,
+  NavPlaceExtension,
+  Reference,
+  SpecificResource,
+  StructuralProperties,
+  TechnicalProperties,
+} from "@iiif/presentation-3";
+import type { resources, technicalProperties } from "@manifest-editor/editor-api";
 import type { ReactNode } from "react";
 import type { CreatorInstance } from "./CreatorInstance";
 import type { CreatorResource } from "./CreatorResource";
 import type { ReferencedResource } from "./ReferencedResource";
+import type { CreatorDefinitionFilterByParent, ExtractCreatorGenerics, IIIFManifestEditor } from "./creator-register";
 
 export interface CreatorContext<T = any> {
   vault: Vault;
@@ -17,11 +28,7 @@ export interface CreatorFunctionContext {
   ref(idOrRef: string | Reference): ReferencedResource;
   embed(data: any): CreatorResource;
 
-  create(
-    definition: string,
-    payload: any,
-    options?: Partial<CreatorOptions>,
-  ): Promise<CreatorResource>;
+  create(definition: string, payload: any, options?: Partial<CreatorOptions>): Promise<CreatorResource>;
   create<Definition extends CreatorDefinition = any>(
     definition: Definition["id"],
     payload: GetCreatorPayload<Definition>,
@@ -35,8 +42,9 @@ export interface CreatorFunctionContext {
   getPreviewVault(): Vault;
 }
 
-export type GetCreatorPayload<T extends CreatorDefinition> =
-  T extends CreatorDefinition<infer Payload> ? Payload : never;
+export type GetCreatorPayload<T extends CreatorDefinition> = T extends CreatorDefinition<infer Payload>
+  ? Payload
+  : never;
 
 interface CreatorParent {
   resource: Reference;
@@ -50,9 +58,45 @@ export interface CreatorOptions {
   initialData?: any;
 }
 
-export interface CreatorDefinition<Payload = any> {
+export type AllAvailableParentTypes = keyof typeof resources.supported;
+
+type ManifestFields = typeof resources.supported.Manifest.all;
+
+export type GetSupportedResourceFields<Resource extends AllAvailableParentTypes> =
+  {} & (typeof resources.supported)[Resource]["allowed"][number];
+
+export type AllProperties =
+  | ({} & keyof LinkingProperties)
+  | ({} & keyof StructuralProperties<any>)
+  | ({} & keyof TechnicalProperties)
+  | ({} & keyof DescriptiveProperties)
+  | ({} & keyof Annotation)
+  | ({} & keyof NavPlaceExtension);
+
+export type AllParentTypes = [
+  "Collection",
+  "Manifest",
+  "Canvas",
+  "Annotation",
+  "AnnotationPage",
+  "Range",
+  "AnnotationCollection",
+  "ContentResource",
+  "Agent",
+];
+
+export interface SpecificCreatorDefinition<
+  //
+  Payload = any,
+  ID = Readonly<string>,
+  ResourceType extends AllAvailableParentTypes = never,
+  AdditionalResourceTypes extends Array<AllAvailableParentTypes> = [],
+  AllResourceTypes = [ResourceType, ...AdditionalResourceTypes],
+  SupportsParentTypes extends Array<AllAvailableParentTypes> = AllParentTypes,
+  SupportsParentFields extends Array<AllProperties> = [],
+> {
   // The creation itself
-  id: string;
+  readonly id: ID;
   label: string;
   summary?: string;
   icon?: any;
@@ -67,8 +111,8 @@ export interface CreatorDefinition<Payload = any> {
   renderModal?: (ctx: CreatorContext<Payload>) => ReactNode;
 
   // What is being created.
-  resourceType: string;
-  additionalTypes?: string[];
+  resourceType: ResourceType;
+  additionalTypes?: AdditionalResourceTypes;
   resourceFields: string[];
   embeddedResources?: string[];
   // This is completely static values. (e.g. {type: 'Image'})
@@ -79,8 +123,8 @@ export interface CreatorDefinition<Payload = any> {
   // Where is it valid?
   supports: {
     initialData?: boolean;
-    parentTypes?: string[];
-    parentFields?: string[];
+    parentTypes?: SupportsParentTypes;
+    parentFields?: SupportsParentFields;
     parentFieldMap?: Record<string, string[]>;
     custom?: (parent: CreatorParent, vault: Vault) => boolean;
     // Edge-case for painting annotations.
@@ -90,11 +134,11 @@ export interface CreatorDefinition<Payload = any> {
   sideEffects?: Array<CreatorSideEffect>;
 }
 
+// Keep this for compatibility.
+export type CreatorDefinition<Payload = any> = SpecificCreatorDefinition<Payload, any, any, any, any, any, any>;
+
 export interface CreatorSideEffect {
-  run?: (
-    result: any,
-    ctx: { options: CreatorOptions; vault: Vault },
-  ) => void | Promise<void>;
+  run?: (result: any, ctx: { options: CreatorOptions; vault: Vault }) => void | Promise<void>;
   temporal?: boolean;
   spatial?: boolean;
   replaceSiblings?: boolean;

--- a/packages/creators/README.md
+++ b/packages/creators/README.md
@@ -1,0 +1,49 @@
+# Creators
+
+## API Design
+
+The current API is a pain to use. Its lacking types.
+
+Essentially this is the current creator hook/API (with no types!).
+
+```ts
+creator.create("@manifest-editor/image-url-creator", newThumbnail, {
+  targetType: "ContentResource",
+  parent: {
+    property: "thumbnail",
+    resource: {
+      id: collection!.id,
+      type: "Collection",
+    },
+  },
+  initialData: {},
+});
+```
+
+Ideally something like this would work, and be type-safe.
+
+```tsx
+
+const resource = { id: ..., type: 'Manifest' }; // Maybe from props or something.
+const createImage = useCreator(
+  // Resource will have a type.
+  resource,
+  // This should be inferred from the resource type + supported fields.
+  "thumbnail",
+  // This should be inferred from the resource type + property supported type.
+  "@manifest-editor/image-url-creator"
+);
+
+// ...
+createImage({ url: 'https://example.org/image.jpg' });
+```
+
+The same thing, but on the editor API.
+
+```ts
+const manifestEditor = useManifestEditor();
+
+await manifestEditor.descriptive.thumbnail.create("@manifest-editor/image-url-creator", {
+  url: "https://example.org/image.jpg",
+});
+```

--- a/packages/creators/src/Annotation/AudioAnnotation/create-audio-annotation.tsx
+++ b/packages/creators/src/Annotation/AudioAnnotation/create-audio-annotation.tsx
@@ -1,22 +1,13 @@
-import type {
-  CreatorContext,
-  CreatorFunctionContext,
-} from "@manifest-editor/creator-api";
-import type { InternationalString } from "@iiif/presentation-3";
-import { useEffect, useState } from "react";
-import { PaddedSidebarContainer } from "@manifest-editor/ui/atoms/PaddedSidebarContainer";
-import { ErrorMessage } from "@manifest-editor/components";
-import { MediaControls } from "@manifest-editor/ui/MediaControls";
-import { CanvasPanel } from "react-iiif-vault";
 import { getValue } from "@iiif/helpers";
-import {
-  Input,
-  InputContainer,
-  InputLabel,
-  LanguageFieldEditor,
-  FormFieldWrapper,
-} from "@manifest-editor/editors";
+import type { InternationalString } from "@iiif/presentation-3";
+import { ErrorMessage } from "@manifest-editor/components";
+import type { CreatorContext, CreatorFunctionContext } from "@manifest-editor/creator-api";
+import { FormFieldWrapper, Input, InputContainer, InputLabel, LanguageFieldEditor } from "@manifest-editor/editors";
+import { MediaControls } from "@manifest-editor/ui/MediaControls";
 import { Button } from "@manifest-editor/ui/atoms/Button";
+import { PaddedSidebarContainer } from "@manifest-editor/ui/atoms/PaddedSidebarContainer";
+import { useEffect, useState } from "react";
+import { CanvasPanel } from "react-iiif-vault";
 
 export interface CreateAudioAnnotationPayload {
   label?: InternationalString;
@@ -25,10 +16,7 @@ export interface CreateAudioAnnotationPayload {
   url: string;
 }
 
-export async function createAudioAnnotation(
-  data: CreateAudioAnnotationPayload,
-  ctx: CreatorFunctionContext,
-) {
+export async function createAudioAnnotation(data: CreateAudioAnnotationPayload, ctx: CreatorFunctionContext) {
   const annotation = {
     id: ctx.generateId("annotation"),
     type: "Annotation",
@@ -36,7 +24,7 @@ export async function createAudioAnnotation(
 
   const targetType = ctx.options.targetType as "Annotation" | "Canvas";
 
-  const body = await ctx.embed({
+  const body = ctx.embed({
     id: data.url,
     type: "Sound",
     format: "audio/mp4",
@@ -47,8 +35,7 @@ export async function createAudioAnnotation(
     return ctx.embed({
       ...annotation,
       label: getValue(data.label) && data.label,
-      motivation:
-        data.motivation || ctx.options.initialData?.motivation || "painting",
+      motivation: data.motivation || ctx.options.initialData?.motivation || "painting",
       body,
       target: ctx.getTarget(),
     });
@@ -87,9 +74,7 @@ export async function createAudioAnnotation(
   }
 }
 
-export function CreateAudioAnnotationForm(
-  props: CreatorContext<CreateAudioAnnotationPayload>,
-) {
+export function CreateAudioAnnotationForm(props: CreatorContext<CreateAudioAnnotationPayload>) {
   const [url, setUrl] = useState("");
   const [duration, setDuration] = useState(0);
   const [error, setError] = useState("");
@@ -119,18 +104,13 @@ export function CreateAudioAnnotationForm(
 
       <InputContainer>
         <InputLabel htmlFor="audio-url">URL</InputLabel>
-        <Input
-          type="text"
-          id="audio-url"
-          value={url}
-          onChange={(e) => setUrl(e.target.value)}
-        />
+        <Input type="text" id="audio-url" value={url} onChange={(e) => setUrl(e.target.value)} />
       </InputContainer>
 
       {url && !error ? (
         <div>
           <LanguageFieldEditor
-            key={url + "__" + duration}
+            key={`${url}__${duration}`}
             containerId={"label"}
             focusId={"label_"}
             label={"Label"}
@@ -141,12 +121,9 @@ export function CreateAudioAnnotationForm(
       ) : null}
 
       {url && !error ? (
-        <CanvasPanel.AudioHTML
-          key={url + "__" + duration}
-          media={{ url, duration, type: "Sound" } as any}
-        >
+        <CanvasPanel.AudioHTML key={`${url}__${duration}`} media={{ url, duration, type: "Sound" } as any}>
           <MediaControls
-            key={url + "__" + duration}
+            key={`${url}__${duration}`}
             onError={(error) => setError(error)}
             onDuration={(duration) => setDuration(duration)}
           />
@@ -156,12 +133,7 @@ export function CreateAudioAnnotationForm(
       {duration && !error ? (
         <FormFieldWrapper>
           <InputLabel htmlFor="duration">Duration</InputLabel>
-          <Input
-            type="number"
-            id="duration"
-            value={duration}
-            onChange={(e) => setDuration(e.target.valueAsNumber)}
-          />
+          <Input type="number" id="duration" value={duration} onChange={(e) => setDuration(e.target.valueAsNumber)} />
         </FormFieldWrapper>
       ) : null}
 

--- a/packages/creators/src/Annotation/AudioAnnotation/index.tsx
+++ b/packages/creators/src/Annotation/AudioAnnotation/index.tsx
@@ -1,13 +1,16 @@
 import { AudioIcon } from "@manifest-editor/components";
-import type { CreatorDefinition } from "@manifest-editor/creator-api";
-import { TextFormatIcon } from "@manifest-editor/ui/icons/TextFormatIcon";
-import {
-  CreateAudioAnnotationForm,
-  type CreateAudioAnnotationPayload,
-  createAudioAnnotation,
-} from "./create-audio-annotation";
+import { defineCreator } from "@manifest-editor/creator-api";
+import { CreateAudioAnnotationForm, createAudioAnnotation } from "./create-audio-annotation";
 
-export const audioAnnotation: CreatorDefinition = {
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@manifest-editor/audio-annotation": typeof audioAnnotation;
+    }
+  }
+}
+
+export const audioAnnotation = defineCreator({
   id: "@manifest-editor/audio-annotation",
   create: createAudioAnnotation,
   label: "Audio",
@@ -27,4 +30,4 @@ export const audioAnnotation: CreatorDefinition = {
   staticFields: {
     type: "Annotation",
   },
-};
+});

--- a/packages/creators/src/Annotation/CaptionedImageAnnotation/index.tsx
+++ b/packages/creators/src/Annotation/CaptionedImageAnnotation/index.tsx
@@ -1,30 +1,33 @@
-import { AddImageIcon, HTMLIcon } from "@manifest-editor/components";
-import type { CreatorDefinition } from "@manifest-editor/creator-api";
-import {
-  CreateCaptionedImageAnnotation,
-  type CreateCaptionedImageAnnotationPayload,
-  createCaptionedImageAnnotation,
-} from "./create-captioned-image-annotation";
+import { AddImageIcon } from "@manifest-editor/components";
+import { defineCreator } from "@manifest-editor/creator-api";
+import { CreateCaptionedImageAnnotation, createCaptionedImageAnnotation } from "./create-captioned-image-annotation";
 
-export const captionedImageAnnotation: CreatorDefinition<CreateCaptionedImageAnnotationPayload> =
-  {
-    id: "@manifest-editor/captioned-image-annotation",
-    create: createCaptionedImageAnnotation,
-    label: "Captioned image",
-    summary: "Add an image from a URL with caption",
-    icon: <AddImageIcon />,
-    render(ctx) {
-      return <CreateCaptionedImageAnnotation {...ctx} />;
-    },
-    resourceType: "Annotation",
-    resourceFields: ["id", "type", "motivation", "body", "target"],
-    additionalTypes: ["Canvas"],
-    supports: {
-      initialData: true,
-      parentTypes: ["AnnotationPage"],
-      parentFields: ["items"],
-    },
-    staticFields: {
-      type: "Annotation",
-    },
-  };
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@manifest-editor/captioned-image-annotation": typeof captionedImageAnnotation;
+    }
+  }
+}
+
+export const captionedImageAnnotation = defineCreator({
+  id: "@manifest-editor/captioned-image-annotation",
+  create: createCaptionedImageAnnotation,
+  label: "Captioned image",
+  summary: "Add an image from a URL with caption",
+  icon: <AddImageIcon />,
+  render(ctx) {
+    return <CreateCaptionedImageAnnotation {...ctx} />;
+  },
+  resourceType: "Annotation",
+  resourceFields: ["id", "type", "motivation", "body", "target"],
+  additionalTypes: ["Canvas"],
+  supports: {
+    initialData: true,
+    parentTypes: ["AnnotationPage"],
+    parentFields: ["items"],
+  },
+  staticFields: {
+    type: "Annotation",
+  },
+});

--- a/packages/creators/src/Annotation/HTMLAnnotation/index.tsx
+++ b/packages/creators/src/Annotation/HTMLAnnotation/index.tsx
@@ -1,12 +1,16 @@
 import { HTMLIcon } from "@manifest-editor/components";
-import type { CreatorDefinition } from "@manifest-editor/creator-api";
-import {
-  CreateHTMLAnnotation,
-  type CreateHTMLAnnotationPayload,
-  createHtmlAnnotation,
-} from "./create-html-annotation";
+import { defineCreator } from "@manifest-editor/creator-api";
+import { CreateHTMLAnnotation, createHtmlAnnotation } from "./create-html-annotation";
 
-export const htmlAnnotation: CreatorDefinition<CreateHTMLAnnotationPayload> = {
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@manifest-editor/html-annotation": typeof htmlAnnotation;
+    }
+  }
+}
+
+export const htmlAnnotation = defineCreator({
   id: "@manifest-editor/html-annotation",
   create: createHtmlAnnotation,
   label: "HTML",
@@ -26,4 +30,4 @@ export const htmlAnnotation: CreatorDefinition<CreateHTMLAnnotationPayload> = {
   staticFields: {
     type: "Annotation",
   },
-};
+});

--- a/packages/creators/src/Annotation/ImageServiceAnnotation/index.tsx
+++ b/packages/creators/src/Annotation/ImageServiceAnnotation/index.tsx
@@ -1,41 +1,39 @@
 import { IIIFLogo } from "@manifest-editor/components";
-import type { CreatorDefinition } from "@manifest-editor/creator-api";
-import { TextFormatIcon } from "@manifest-editor/ui/icons/TextFormatIcon";
+import { defineCreator } from "@manifest-editor/creator-api";
 import { repositionMultipleImages } from "../../side-effects/reposition-multiple-images";
 import { resizeResourceToEmptyCanvas } from "../../side-effects/resize-resource-to-empty-canvas";
 import { resizeToFitService } from "../../side-effects/resize-to-fit-service";
-import {
-  CreateImageServiceAnnotationForm,
-  type CreateImageServiceAnnotationPayload,
-  createImageServiceAnnotation,
-} from "./create-service-annotation";
+import { CreateImageServiceAnnotationForm, createImageServiceAnnotation } from "./create-service-annotation";
+
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@manifest-editor/image-service-annotation": typeof imageServiceAnnotation;
+    }
+  }
+}
 
 // @todo combine this with the content resource one.
-export const imageServiceAnnotation: CreatorDefinition<CreateImageServiceAnnotationPayload> =
-  {
-    id: "@manifest-editor/image-service-annotation",
-    create: createImageServiceAnnotation,
-    label: "IIIF Image",
-    dependencies: ["@manifest-editor/image-service-creator"],
-    summary: "IIIF Image service",
-    tags: ["image", "image-service"],
-    icon: <IIIFLogo style={{ padding: 10 }} />,
-    render(ctx) {
-      return <CreateImageServiceAnnotationForm {...ctx} />;
-    },
-    resourceType: "Annotation",
-    resourceFields: ["id", "type", "motivation", "body", "target"],
-    additionalTypes: ["Canvas"],
-    supports: {
-      parentTypes: ["AnnotationPage", "Manifest"],
-      parentFields: ["items"],
-    },
-    sideEffects: [
-      resizeToFitService,
-      resizeResourceToEmptyCanvas,
-      repositionMultipleImages,
-    ],
-    staticFields: {
-      type: "Annotation",
-    },
-  };
+export const imageServiceAnnotation = defineCreator({
+  id: "@manifest-editor/image-service-annotation",
+  create: createImageServiceAnnotation,
+  label: "IIIF Image",
+  dependencies: ["@manifest-editor/image-service-creator"],
+  summary: "IIIF Image service",
+  tags: ["image", "image-service"],
+  icon: <IIIFLogo style={{ padding: 10 }} />,
+  render(ctx) {
+    return <CreateImageServiceAnnotationForm {...ctx} />;
+  },
+  resourceType: "Annotation",
+  resourceFields: ["id", "type", "motivation", "body", "target"],
+  additionalTypes: ["Canvas"],
+  supports: {
+    parentTypes: ["AnnotationPage", "Manifest"],
+    parentFields: ["items"],
+  },
+  sideEffects: [resizeToFitService, resizeResourceToEmptyCanvas, repositionMultipleImages],
+  staticFields: {
+    type: "Annotation",
+  },
+});

--- a/packages/creators/src/Annotation/ImageUrlAnnotation/index.tsx
+++ b/packages/creators/src/Annotation/ImageUrlAnnotation/index.tsx
@@ -1,39 +1,38 @@
 import { AddImageIcon } from "@manifest-editor/components";
-import type { CreatorDefinition } from "@manifest-editor/creator-api";
+import { defineCreator } from "@manifest-editor/creator-api";
 import { repositionMultipleImages } from "../../side-effects/reposition-multiple-images";
 import { resizeResourceToEmptyCanvas } from "../../side-effects/resize-resource-to-empty-canvas";
 import { resizeToFitService } from "../../side-effects/resize-to-fit-service";
-import {
-  CreateImageUrlAnnotationForm,
-  type CreateImageUrlAnnotationPayload,
-  createImageUrlAnnotation,
-} from "./create-image-url-annotation";
+import { CreateImageUrlAnnotationForm, createImageUrlAnnotation } from "./create-image-url-annotation";
 
-export const imageUrlAnnotation: CreatorDefinition<CreateImageUrlAnnotationPayload> =
-  {
-    id: "@manifest-editor/image-url-annotation",
-    create: createImageUrlAnnotation,
-    label: "Image",
-    dependencies: ["@manifest-editor/image-url-creator"],
-    summary: "Image from URL",
-    tags: ["image"],
-    icon: <AddImageIcon />,
-    render(ctx) {
-      return <CreateImageUrlAnnotationForm {...ctx} />;
-    },
-    resourceType: "Annotation",
-    resourceFields: ["id", "type", "motivation", "body", "target"],
-    additionalTypes: ["Canvas"],
-    supports: {
-      parentTypes: ["AnnotationPage", "Manifest"],
-      parentFields: ["items"],
-    },
-    sideEffects: [
-      resizeToFitService,
-      resizeResourceToEmptyCanvas,
-      repositionMultipleImages,
-    ],
-    staticFields: {
-      type: "Annotation",
-    },
-  };
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@manifest-editor/image-url-annotation": typeof imageUrlAnnotation;
+    }
+  }
+}
+
+export const imageUrlAnnotation = defineCreator({
+  id: "@manifest-editor/image-url-annotation",
+  create: createImageUrlAnnotation,
+  label: "Image",
+  dependencies: ["@manifest-editor/image-url-creator"],
+  summary: "Image from URL",
+  tags: ["image"],
+  icon: <AddImageIcon />,
+  render(ctx) {
+    return <CreateImageUrlAnnotationForm {...ctx} />;
+  },
+  resourceType: "Annotation",
+  resourceFields: ["id", "type", "motivation", "body", "target"],
+  additionalTypes: ["Canvas"],
+  supports: {
+    parentTypes: ["AnnotationPage", "Manifest"],
+    parentFields: ["items"],
+  },
+  sideEffects: [resizeToFitService, resizeResourceToEmptyCanvas, repositionMultipleImages],
+  staticFields: {
+    type: "Annotation",
+  },
+});

--- a/packages/creators/src/Annotation/NoBodyAnnotation/index.tsx
+++ b/packages/creators/src/Annotation/NoBodyAnnotation/index.tsx
@@ -1,18 +1,23 @@
 import type { InternationalString } from "@iiif/presentation-3";
 import { EmptyCanvasIcon } from "@manifest-editor/components";
-import type {
-  CreatorDefinition,
-  CreatorFunctionContext,
-} from "@manifest-editor/creator-api";
+import { type CreatorFunctionContext, defineCreator } from "@manifest-editor/creator-api";
 
 // @todo combine this with the content resource one.
+
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@manifest-editor/no-body-annotation": typeof noBodyAnnotation;
+    }
+  }
+}
 
 export interface NoBodyAnnotationPayload {
   label?: InternationalString;
   motivation?: string;
 }
 
-export const noBodyAnnotation: CreatorDefinition<NoBodyAnnotationPayload> = {
+export const noBodyAnnotation = defineCreator({
   id: "@manifest-editor/no-body-annotation",
   create: createNoBodyAnnotation,
   label: "Annotation without body",
@@ -30,18 +35,14 @@ export const noBodyAnnotation: CreatorDefinition<NoBodyAnnotationPayload> = {
   staticFields: {
     type: "Annotation",
   },
-};
+});
 
-export function createNoBodyAnnotation(
-  data: NoBodyAnnotationPayload,
-  ctx: CreatorFunctionContext,
-) {
+export function createNoBodyAnnotation(data: NoBodyAnnotationPayload, ctx: CreatorFunctionContext) {
   return ctx.embed({
     id: ctx.generateId("annotation"),
     type: "Annotation",
     label: data?.label,
-    motivation:
-      data.motivation || ctx.options.initialData?.motivation || "highlighting",
+    motivation: data.motivation || ctx.options.initialData?.motivation || "highlighting",
     target: ctx.getTarget(),
   });
 }

--- a/packages/creators/src/Annotation/VideoAnnotation/index.tsx
+++ b/packages/creators/src/Annotation/VideoAnnotation/index.tsx
@@ -1,30 +1,33 @@
 import { VideoIcon } from "@manifest-editor/components";
-import type { CreatorDefinition } from "@manifest-editor/creator-api";
-import {
-  CreateVideoAnnotationForm,
-  type CreateVideoAnnotationPayload,
-  createVideoAnnotation,
-} from "./create-video-annotation";
+import { defineCreator } from "@manifest-editor/creator-api";
+import { CreateVideoAnnotationForm, createVideoAnnotation } from "./create-video-annotation";
 
-export const videoAnnotation: CreatorDefinition<CreateVideoAnnotationPayload> =
-  {
-    id: "@manifest-editor/video-annotation",
-    create: createVideoAnnotation,
-    label: "Video",
-    summary: "Video annotation",
-    icon: <VideoIcon />,
-    render(ctx) {
-      return <CreateVideoAnnotationForm {...ctx} />;
-    },
-    resourceType: "Annotation",
-    resourceFields: ["id", "type", "motivation", "body", "target"],
-    additionalTypes: ["Canvas"],
-    supports: {
-      initialData: true,
-      parentTypes: ["AnnotationPage", "Manifest"],
-      parentFields: ["items"],
-    },
-    staticFields: {
-      type: "Annotation",
-    },
-  };
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@manifest-editor/video-annotation": typeof videoAnnotation;
+    }
+  }
+}
+
+export const videoAnnotation = defineCreator({
+  id: "@manifest-editor/video-annotation",
+  create: createVideoAnnotation,
+  label: "Video",
+  summary: "Video annotation",
+  icon: <VideoIcon />,
+  render(ctx) {
+    return <CreateVideoAnnotationForm {...ctx} />;
+  },
+  resourceType: "Annotation",
+  resourceFields: ["id", "type", "motivation", "body", "target"],
+  additionalTypes: ["Canvas"],
+  supports: {
+    initialData: true,
+    parentTypes: ["AnnotationPage", "Manifest"],
+    parentFields: ["items"],
+  },
+  staticFields: {
+    type: "Annotation",
+  },
+});

--- a/packages/creators/src/AnnotationPage/EmptyAnnotationPage/index.tsx
+++ b/packages/creators/src/AnnotationPage/EmptyAnnotationPage/index.tsx
@@ -1,12 +1,23 @@
 import type { InternationalString } from "@iiif/presentation-3";
-import type { CreatorDefinition } from "@manifest-editor/creator-api";
+import { defineCreator } from "@manifest-editor/creator-api";
 import { ThumbnailStripIcon } from "@manifest-editor/ui/icons/ThumbnailStripIcon";
 
-export const emptyAnnotationPage: CreatorDefinition<{
-  label?: InternationalString;
-}> = {
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@manifest-editor/empty-annotation-page": typeof emptyAnnotationPage;
+    }
+  }
+}
+
+export const emptyAnnotationPage = defineCreator({
   id: "@manifest-editor/empty-annotation-page",
-  create: (data, ctx) => {
+  create: (
+    data: {
+      label?: InternationalString;
+    },
+    ctx,
+  ) => {
     return ctx.embed({
       id: ctx.generateId("annotations"),
       label: data.label,
@@ -27,4 +38,4 @@ export const emptyAnnotationPage: CreatorDefinition<{
       Range: ["annotations"],
     },
   },
-};
+});

--- a/packages/creators/src/Canvas/EmptyCanvas/index.tsx
+++ b/packages/creators/src/Canvas/EmptyCanvas/index.tsx
@@ -1,14 +1,25 @@
 import type { InternationalString } from "@iiif/presentation-3";
 import { EmptyCanvasIcon } from "@manifest-editor/components";
-import type { CreatorDefinition } from "@manifest-editor/creator-api";
+import { defineCreator } from "@manifest-editor/creator-api";
 
-export const emptyCanvas: CreatorDefinition<{
-  label?: InternationalString;
-  width?: number;
-  height?: number;
-}> = {
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@manifest-editor/empty-canvas": typeof emptyCanvas;
+    }
+  }
+}
+
+export const emptyCanvas = defineCreator({
   id: "@manifest-editor/empty-canvas",
-  create: (data, ctx) => {
+  create: (
+    data: {
+      label?: InternationalString;
+      width?: number;
+      height?: number;
+    },
+    ctx,
+  ) => {
     const canvasId = ctx.generateId("canvas");
     const page = ctx.embed({
       id: ctx.generateId("annotation-page", { id: canvasId, type: "Canvas" }),
@@ -34,4 +45,4 @@ export const emptyCanvas: CreatorDefinition<{
     parentTypes: ["Manifest"],
     parentFields: ["items"],
   },
-};
+});

--- a/packages/creators/src/Canvas/InternalCanvas/index.tsx
+++ b/packages/creators/src/Canvas/InternalCanvas/index.tsx
@@ -1,14 +1,18 @@
-import type {
-  CreatorContext,
-  CreatorDefinition,
-  CreatorFunctionContext,
-} from "@manifest-editor/creator-api";
+import { type CreatorContext, type CreatorFunctionContext, defineCreator } from "@manifest-editor/creator-api";
 import { IIIFExplorer } from "@manifest-editor/iiif-browser";
 import { ThumbnailStripIcon } from "@manifest-editor/ui/icons/ThumbnailStripIcon";
 import { useManifest, useVault } from "react-iiif-vault";
 import invariant from "tiny-invariant";
 
-export const internalCanvas: CreatorDefinition<InternalCanvasPayload> = {
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@manifest-editor/internal-canvas": typeof internalCanvas;
+    }
+  }
+}
+
+export const internalCanvas = defineCreator({
   id: "@manifest-editor/internal-canvas",
   create: createInternalCanvas,
   label: "Internal canvas link",
@@ -21,7 +25,7 @@ export const internalCanvas: CreatorDefinition<InternalCanvasPayload> = {
     parentFields: ["start"],
   },
   render: (ctx) => <InternalCanvas {...ctx} />,
-};
+});
 
 function InternalCanvas(props: CreatorContext<InternalCanvasPayload>) {
   const manifest = useManifest();
@@ -55,9 +59,6 @@ export interface InternalCanvasPayload {
   id: string;
 }
 
-async function createInternalCanvas(
-  data: InternalCanvasPayload,
-  ctx: CreatorFunctionContext,
-) {
+async function createInternalCanvas(data: InternalCanvasPayload, ctx: CreatorFunctionContext) {
   return ctx.embed({ id: data.id, type: "Canvas" });
 }

--- a/packages/creators/src/ContentResource/HTMLBodyCreator/index.tsx
+++ b/packages/creators/src/ContentResource/HTMLBodyCreator/index.tsx
@@ -1,12 +1,16 @@
-import type { CreatorDefinition } from "@manifest-editor/creator-api";
+import { defineCreator } from "@manifest-editor/creator-api";
 import { TextFormatIcon } from "@manifest-editor/ui/icons/TextFormatIcon";
-import {
-  CreateHTMLBodyForm,
-  type CreateHTMLBodyPayload,
-  createHtmlBody,
-} from "./create-html-body";
+import { CreateHTMLBodyForm, createHtmlBody } from "./create-html-body";
 
-export const htmlBodyCreator: CreatorDefinition<CreateHTMLBodyPayload> = {
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@manifest-editor/html-body-creator": typeof htmlBodyCreator;
+    }
+  }
+}
+
+export const htmlBodyCreator = defineCreator({
   id: "@manifest-editor/html-body-creator",
   create: createHtmlBody,
   label: "HTML Body",
@@ -25,4 +29,4 @@ export const htmlBodyCreator: CreatorDefinition<CreateHTMLBodyPayload> = {
     type: "TextualBody",
     format: "text/html",
   },
-};
+});

--- a/packages/creators/src/ContentResource/IIIFBrowserCreator/index.tsx
+++ b/packages/creators/src/ContentResource/IIIFBrowserCreator/index.tsx
@@ -1,42 +1,41 @@
 import { IIIFBrowserIcon } from "@manifest-editor/components";
-import type { CreatorDefinition } from "@manifest-editor/creator-api";
-import { TextFormatIcon } from "@manifest-editor/ui/icons/TextFormatIcon";
+import { defineCreator } from "@manifest-editor/creator-api";
 import { repositionMultipleImages } from "../../side-effects/reposition-multiple-images";
 import { resizeResourceToEmptyCanvas } from "../../side-effects/resize-resource-to-empty-canvas";
 import { resizeToFitService } from "../../side-effects/resize-to-fit-service";
-import {
-  IIIFBrowserCreatorForm,
-  type IIIFBrowserCreatorPayload,
-  createFromIIIFBrowserOutput,
-} from "./iiif-browser-creator";
+import { IIIFBrowserCreatorForm, createFromIIIFBrowserOutput } from "./iiif-browser-creator";
 
-export const iiifBrowserCreator: CreatorDefinition<IIIFBrowserCreatorPayload> =
-  {
-    id: "@manifest-editor/iiif-browser-creator",
-    create: createFromIIIFBrowserOutput,
-    label: "IIIF Browser",
-    summary: "Browse IIIF Resources",
-    icon: <IIIFBrowserIcon />,
-    render(ctx: any) {
-      return <IIIFBrowserCreatorForm {...ctx} />;
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@manifest-editor/iiif-browser-creator": typeof iiifBrowserCreator;
+    }
+  }
+}
+
+export const iiifBrowserCreator = defineCreator({
+  id: "@manifest-editor/iiif-browser-creator",
+  create: createFromIIIFBrowserOutput,
+  label: "IIIF Browser",
+  summary: "Browse IIIF Resources",
+  icon: <IIIFBrowserIcon />,
+  render(ctx: any) {
+    return <IIIFBrowserCreatorForm {...ctx} />;
+  },
+  hiddenModal: true,
+  tags: ["image", "image-service"],
+  resourceType: "ContentResource",
+  resourceFields: ["id", "language", "type", "format", "value"],
+  additionalTypes: ["Annotation", "Canvas"],
+  supports: {
+    parentTypes: ["Annotation", "Manifest", "AnnotationPage"],
+    parentFields: ["body", "items"],
+    parentFieldMap: {
+      Annotation: ["body"],
+      Manifest: ["items"],
+      AnnotationPage: ["items"],
     },
-    hiddenModal: true,
-    tags: ["image", "image-service"],
-    resourceType: "ContentResource",
-    resourceFields: ["id", "language", "type", "format", "value"],
-    additionalTypes: ["Annotation", "Canvas"],
-    supports: {
-      parentTypes: ["Annotation", "Manifest", "AnnotationPage"],
-      parentFieldMap: {
-        Annotation: ["body"],
-        Manifest: ["items"],
-        AnnotationPage: ["items"],
-      },
-    },
-    sideEffects: [
-      resizeToFitService,
-      resizeResourceToEmptyCanvas,
-      repositionMultipleImages,
-    ],
-    staticFields: {},
-  };
+  },
+  sideEffects: [resizeToFitService, resizeResourceToEmptyCanvas, repositionMultipleImages],
+  staticFields: {},
+});

--- a/packages/creators/src/ContentResource/ImageServiceCreator/index.tsx
+++ b/packages/creators/src/ContentResource/ImageServiceCreator/index.tsx
@@ -1,24 +1,27 @@
-import type { CreatorDefinition } from "@manifest-editor/creator-api";
+import { defineCreator } from "@manifest-editor/creator-api";
 import { TextFormatIcon } from "@manifest-editor/ui/icons/TextFormatIcon";
-import {
-  CreateImageServerForm,
-  type CreateImageServicePayload,
-  createImageServer,
-} from "./create-image-service";
+import { CreateImageServerForm, createImageServer } from "./create-image-service";
 
-export const imageServiceCreator: CreatorDefinition<CreateImageServicePayload> =
-  {
-    id: "@manifest-editor/image-service-creator",
-    create: createImageServer,
-    label: "Image Service",
-    summary: "Add an image from Image Service",
-    icon: <TextFormatIcon />,
-    render(ctx) {
-      return <CreateImageServerForm {...ctx} />;
-    },
-    resourceType: "ContentResource",
-    resourceFields: ["id", "type", "height", "width", "format", "service"],
-    supports: {
-      parentFields: ["logo", "body", "thumbnail"],
-    },
-  };
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@manifest-editor/image-service-creator": typeof imageServiceCreator;
+    }
+  }
+}
+
+export const imageServiceCreator = defineCreator({
+  id: "@manifest-editor/image-service-creator",
+  create: createImageServer,
+  label: "Image Service",
+  summary: "Add an image from Image Service",
+  icon: <TextFormatIcon />,
+  render(ctx) {
+    return <CreateImageServerForm {...ctx} />;
+  },
+  resourceType: "ContentResource",
+  resourceFields: ["id", "type", "height", "width", "format", "service"],
+  supports: {
+    parentFields: ["logo", "body", "thumbnail"],
+  },
+});

--- a/packages/creators/src/ContentResource/ImageUrlCreator/index.tsx
+++ b/packages/creators/src/ContentResource/ImageUrlCreator/index.tsx
@@ -1,12 +1,16 @@
 import { AddImageIcon } from "@manifest-editor/components";
-import type { CreatorDefinition } from "@manifest-editor/creator-api";
-import {
-  CreateImageUrlForm,
-  type CreateImageUrlPayload,
-  createImageUrl,
-} from "./create-image-url";
+import { defineCreator } from "@manifest-editor/creator-api";
+import { CreateImageUrlForm, createImageUrl } from "./create-image-url";
 
-export const imageUrlCreator: CreatorDefinition<CreateImageUrlPayload> = {
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@manifest-editor/image-url-creator": typeof imageUrlCreator;
+    }
+  }
+}
+
+export const imageUrlCreator = defineCreator({
   id: "@manifest-editor/image-url-creator",
   create: createImageUrl,
   label: "Image",
@@ -23,4 +27,4 @@ export const imageUrlCreator: CreatorDefinition<CreateImageUrlPayload> = {
   staticFields: {
     type: "Image",
   },
-};
+});

--- a/packages/creators/src/ContentResource/PlaintextCreator/index.tsx
+++ b/packages/creators/src/ContentResource/PlaintextCreator/index.tsx
@@ -1,12 +1,16 @@
-import type { CreatorDefinition } from "@manifest-editor/creator-api";
+import { defineCreator } from "@manifest-editor/creator-api";
 import { TextFormatIcon } from "@manifest-editor/ui/icons/TextFormatIcon";
-import {
-  CreatePlaintextForm,
-  createPlaintext,
-  type CreatePlaintextPayload,
-} from "./create-plaintext";
+import { CreatePlaintextForm, createPlaintext } from "./create-plaintext";
 
-export const plaintextCreator: CreatorDefinition<CreatePlaintextPayload> = {
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@manifest-editor/plaintext-creator": typeof plaintextCreator;
+    }
+  }
+}
+
+export const plaintextCreator = defineCreator({
   id: "@manifest-editor/plaintext-creator",
   create: createPlaintext,
   label: "Plaintext",
@@ -23,4 +27,4 @@ export const plaintextCreator: CreatorDefinition<CreatePlaintextPayload> = {
   staticFields: {
     format: "text/plain",
   },
-};
+});

--- a/packages/creators/src/ContentResource/WebPageCreator/index.tsx
+++ b/packages/creators/src/ContentResource/WebPageCreator/index.tsx
@@ -1,12 +1,16 @@
-import type { CreatorDefinition } from "@manifest-editor/creator-api";
+import { defineCreator } from "@manifest-editor/creator-api";
 import { LinkIcon } from "@manifest-editor/ui/icons/LinkIcon";
-import {
-  CreateWebPageForm,
-  type CreateWebpagePayload,
-  createWebPage,
-} from "./create-web-page";
+import { CreateWebPageForm, createWebPage } from "./create-web-page";
 
-export const webPageCreator: CreatorDefinition<CreateWebpagePayload> = {
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@manifest-editor/web-page-creator": typeof webPageCreator;
+    }
+  }
+}
+
+export const webPageCreator = defineCreator({
   id: "@manifest-editor/web-page-creator",
   create: createWebPage,
   label: "Web page",
@@ -20,4 +24,4 @@ export const webPageCreator: CreatorDefinition<CreateWebpagePayload> = {
   supports: {
     parentFields: ["seeAlso", "rendering", "homepage"],
   },
-};
+});

--- a/packages/creators/src/ContentResource/YouTubeCreator/index.tsx
+++ b/packages/creators/src/ContentResource/YouTubeCreator/index.tsx
@@ -1,12 +1,16 @@
 import { YouTubeIcon } from "@manifest-editor/components";
-import type { CreatorDefinition } from "@manifest-editor/creator-api";
-import {
-  type CreateYouTubeBodyPayload,
-  YouTubeForm,
-  createYoutubeBody,
-} from "./create-youtube-body";
+import { defineCreator } from "@manifest-editor/creator-api";
+import { YouTubeForm, createYoutubeBody } from "./create-youtube-body";
 
-export const youTubeBodyCreator: CreatorDefinition<CreateYouTubeBodyPayload> = {
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@manifest-editor/youtube": typeof youTubeBodyCreator;
+    }
+  }
+}
+
+export const youTubeBodyCreator = defineCreator({
   id: "@manifest-editor/youtube",
   create: createYoutubeBody,
   label: "YouTube",
@@ -27,4 +31,4 @@ export const youTubeBodyCreator: CreatorDefinition<CreateYouTubeBodyPayload> = {
   staticFields: {
     type: "Video",
   },
-};
+});

--- a/packages/creators/src/ExampleCreator/index.tsx
+++ b/packages/creators/src/ExampleCreator/index.tsx
@@ -1,11 +1,16 @@
 import type { InternationalString } from "@iiif/presentation-3";
 import { EmptyCanvasIcon } from "@manifest-editor/components";
-import type {
-  CreatorDefinition,
-  CreatorFunctionContext,
-} from "@manifest-editor/creator-api";
+import { type CreatorDefinition, type CreatorFunctionContext, defineCreator } from "@manifest-editor/creator-api";
 
-export const exampleCreator: CreatorDefinition<ExampleCanvasPayload> = {
+// declare module "@manifest-editor/creator-api" {
+//   namespace IIIFManifestEditor {
+//     interface CreatorDefinitions {
+//       "@manifest-editor/example-creator": typeof exampleCreator;
+//     }
+//   }
+// }
+
+export const exampleCreator = defineCreator({
   id: "@manifest-editor/example-creator",
   create: createExampleCanvas,
   label: "Example Creator",
@@ -17,7 +22,7 @@ export const exampleCreator: CreatorDefinition<ExampleCanvasPayload> = {
     parentTypes: ["Manifest"],
     parentFields: ["items"],
   },
-};
+});
 
 interface ExampleCanvasPayload {
   label?: InternationalString;
@@ -26,10 +31,7 @@ interface ExampleCanvasPayload {
   behavior?: string[];
 }
 
-async function createExampleCanvas(
-  data: ExampleCanvasPayload,
-  ctx: CreatorFunctionContext,
-) {
+async function createExampleCanvas(data: ExampleCanvasPayload, ctx: CreatorFunctionContext) {
   const canvasId = ctx.generateId("canvas");
   const page = ctx.embed({
     id: ctx.generateId("annotation-page", { id: canvasId, type: "Canvas" }),

--- a/packages/creators/src/Manifest/ManifestBrowserCreator/index.tsx
+++ b/packages/creators/src/Manifest/ManifestBrowserCreator/index.tsx
@@ -1,12 +1,19 @@
 import { IIIFBrowserIcon } from "@manifest-editor/components";
-import type { CreatorDefinition } from "@manifest-editor/creator-api";
-import {
-  type ManifestBrowserCreatorPayload,
-  createFromManifestBrowserOutput,
-} from "./manifest-browser-creator";
+import { defineCreator } from "@manifest-editor/creator-api";
+import { createFromManifestBrowserOutput } from "./manifest-browser-creator";
 import ManifestBrowserCreatorForm from "./manifest-browser-form.lazy";
 
-export const manifestBrowserCreator: CreatorDefinition = {
+export type { ManifestBrowserCreatorPayload } from "./manifest-browser-creator";
+
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@manifest-editor/manifest-browser-creator": typeof manifestBrowserCreator;
+    }
+  }
+}
+
+export const manifestBrowserCreator = defineCreator({
   id: "@manifest-editor/manifest-browser-creator",
   create: createFromManifestBrowserOutput,
   label: "IIIF Browser",
@@ -26,4 +33,4 @@ export const manifestBrowserCreator: CreatorDefinition = {
   },
   sideEffects: [],
   staticFields: {},
-};
+});

--- a/packages/creators/src/index.ts
+++ b/packages/creators/src/index.ts
@@ -32,6 +32,7 @@ export * from "./ContentResource/ImageUrlCreator/create-image-url";
 export * from "./ContentResource/PlaintextCreator/create-plaintext";
 export * from "./ContentResource/WebPageCreator/create-web-page";
 export * from "./ContentResource/YouTubeCreator/create-youtube-body";
+export * from "./Manifest/ManifestBrowserCreator/manifest-browser-creator";
 
 export const allCreators = [
   // Images first.

--- a/packages/editor-api/src/meta/behavior.ts
+++ b/packages/editor-api/src/meta/behavior.ts
@@ -1,4 +1,4 @@
-import { InternationalString } from "@iiif/presentation-3";
+import type { InternationalString } from "@iiif/presentation-3";
 
 export interface BehaviorChoice {
   id: string;

--- a/packages/editor-api/src/meta/descriptive.ts
+++ b/packages/editor-api/src/meta/descriptive.ts
@@ -1,6 +1,6 @@
-import { DescriptiveProperties } from "@iiif/presentation-3";
+import type { DescriptiveProperties } from "@iiif/presentation-3";
 
-const required: DescriptiveMap = {
+const required = {
   Collection: ["label"],
   Manifest: ["label"],
   Canvas: [],
@@ -10,9 +10,9 @@ const required: DescriptiveMap = {
   AnnotationCollection: [],
   ContentResource: [],
   Agent: ["label"],
-} as const;
+} as const satisfies DescriptiveMap;
 
-const recommended: DescriptiveMap = {
+const recommended = {
   Collection: ["metadata", "summary", "provider", "thumbnail"],
   Manifest: ["metadata", "summary", "provider", "thumbnail"],
   Canvas: ["label"],
@@ -22,9 +22,9 @@ const recommended: DescriptiveMap = {
   AnnotationCollection: ["label"],
   ContentResource: ["label"],
   Agent: [],
-} as const;
+} as const satisfies DescriptiveMap;
 
-const optional: DescriptiveMap = {
+const optional = {
   Collection: ["requiredStatement", "rights", "navDate", "placeholderCanvas", "accompanyingCanvas"],
   Manifest: ["requiredStatement", "rights", "navDate", "placeholderCanvas", "accompanyingCanvas"],
   Canvas: [
@@ -54,9 +54,9 @@ const optional: DescriptiveMap = {
   AnnotationCollection: ["metadata", "summary", "requiredStatement", "rights", "provider", "thumbnail"],
   ContentResource: ["label", "metadata", "summary", "requiredStatement", "rights", "provider", "thumbnail"],
   Agent: [],
-} as const;
+} as const satisfies DescriptiveMap;
 
-const notAllowed: DescriptiveMap = {
+const notAllowed = {
   Collection: ["language"],
   Manifest: ["language"],
   Canvas: ["language"],
@@ -77,7 +77,7 @@ const notAllowed: DescriptiveMap = {
     "placeholderCanvas",
     "accompanyingCanvas",
   ],
-} as const;
+} as const satisfies DescriptiveMap;
 
 type DescriptiveMap = Record<
   | "Collection"
@@ -92,7 +92,7 @@ type DescriptiveMap = Record<
   readonly (keyof DescriptiveProperties)[]
 >;
 
-const all: readonly (keyof DescriptiveProperties)[] = [
+const all = [
   "label",
   "summary",
   "metadata",
@@ -104,7 +104,7 @@ const all: readonly (keyof DescriptiveProperties)[] = [
   "provider",
   "placeholderCanvas",
   "accompanyingCanvas",
-];
+] as const;
 
 export const descriptiveProperties = {
   all,

--- a/packages/editor-api/src/meta/extensions.ts
+++ b/packages/editor-api/src/meta/extensions.ts
@@ -1,8 +1,8 @@
-import { NavPlaceExtension, TextGranularityExtension } from "@iiif/presentation-3";
+import type { NavPlaceExtension, TextGranularityExtension } from "@iiif/presentation-3";
 
 export type ExtensionProperties = TextGranularityExtension & NavPlaceExtension;
 
-const required: ExtensionsMap = {
+const required = {
   Collection: [],
   Manifest: [],
   Canvas: [],
@@ -12,9 +12,9 @@ const required: ExtensionsMap = {
   AnnotationCollection: [],
   ContentResource: [],
   Agent: [],
-} as const;
+} as const satisfies ExtensionsMap;
 
-const recommended: ExtensionsMap = {
+const recommended = {
   Collection: [],
   Manifest: [],
   Canvas: [],
@@ -24,9 +24,9 @@ const recommended: ExtensionsMap = {
   AnnotationCollection: [],
   ContentResource: [],
   Agent: [],
-} as const;
+} as const satisfies ExtensionsMap;
 
-const optional: ExtensionsMap = {
+const optional = {
   Collection: ["navPlace"],
   Manifest: ["navPlace"],
   Canvas: ["navPlace"],
@@ -36,9 +36,9 @@ const optional: ExtensionsMap = {
   AnnotationCollection: [],
   ContentResource: [],
   Agent: [],
-} as const;
+} as const satisfies ExtensionsMap;
 
-const notAllowed: ExtensionsMap = {
+const notAllowed = {
   Collection: ["textGranularity"],
   Manifest: ["textGranularity"],
   Canvas: ["textGranularity"],
@@ -48,7 +48,7 @@ const notAllowed: ExtensionsMap = {
   AnnotationCollection: ["textGranularity", "navPlace"],
   ContentResource: ["textGranularity", "navPlace"],
   Agent: ["textGranularity", "navPlace"],
-} as const;
+} as const satisfies ExtensionsMap;
 
 type ExtensionsMap = Record<
   | "Collection"

--- a/packages/editor-api/src/meta/linking.ts
+++ b/packages/editor-api/src/meta/linking.ts
@@ -1,6 +1,6 @@
-import { LinkingProperties } from "@iiif/presentation-3";
+import type { LinkingProperties } from "@iiif/presentation-3";
 
-const required: LinkingMap = {
+const required = {
   Collection: [],
   Manifest: [],
   Canvas: [],
@@ -10,9 +10,9 @@ const required: LinkingMap = {
   AnnotationCollection: [],
   ContentResource: [],
   Agent: [],
-} as const;
+} as const satisfies LinkingMap;
 
-const recommended: LinkingMap = {
+const recommended = {
   Collection: [],
   Manifest: [],
   Canvas: [],
@@ -22,9 +22,9 @@ const recommended: LinkingMap = {
   AnnotationCollection: [],
   ContentResource: [],
   Agent: ["homepage", "logo"],
-} as const;
+} as const satisfies LinkingMap;
 
-const optional: LinkingMap = {
+const optional = {
   Collection: ["seeAlso", "service", "homepage", "rendering", "partOf", "services"],
   Manifest: ["seeAlso", "service", "homepage", "rendering", "partOf", "start", "services"],
   Canvas: ["seeAlso", "service", "homepage", "rendering", "partOf"],
@@ -34,9 +34,9 @@ const optional: LinkingMap = {
   AnnotationCollection: ["seeAlso", "service", "homepage", "rendering", "partOf"],
   ContentResource: ["seeAlso", "service", "homepage", "rendering", "partOf"],
   Agent: ["seeAlso"],
-} as const;
+} as const satisfies LinkingMap;
 
-const notAllowed: LinkingMap = {
+const notAllowed = {
   Collection: ["supplementary", "logo"],
   Manifest: ["supplementary", "logo"],
   Canvas: ["start", "supplementary", "services", "logo"],
@@ -46,7 +46,7 @@ const notAllowed: LinkingMap = {
   AnnotationCollection: ["start", "supplementary", "services", "logo"],
   ContentResource: ["start", "supplementary", "services", "logo"],
   Agent: ["service", "homepage", "rendering", "partOf", "services", "start", "supplementary"],
-} as const;
+} as const satisfies LinkingMap;
 
 type LinkingMap = Record<
   | "Collection"

--- a/packages/editor-api/src/meta/references.ts
+++ b/packages/editor-api/src/meta/references.ts
@@ -8,9 +8,9 @@ const externalProperties = [
   "logo",
   "body",
   "annotations",
-];
+] as const;
 
-const inlineProperties = ["service", "services"];
+const inlineProperties = ["service", "services"] as const;
 
 const internalProperties = [
   "target",
@@ -22,7 +22,7 @@ const internalProperties = [
   "items",
   "structures",
   "annotations",
-];
+] as const;
 
 const all = [
   "target",
@@ -43,9 +43,9 @@ const all = [
   "items",
   "structures",
   "annotations",
-];
+] as const;
 
-const single = ["start", "target"];
+const single = ["start", "target"] as const;
 
 export const references = {
   all,

--- a/packages/editor-api/src/meta/resources.ts
+++ b/packages/editor-api/src/meta/resources.ts
@@ -1,8 +1,8 @@
 import { descriptiveProperties } from "./descriptive";
+import { extensionProperties } from "./extensions";
 import { linkingProperties } from "./linking";
 import { structuralProperties } from "./structural";
 import { technicalProperties } from "./technical";
-import { extensionProperties } from "./extensions";
 
 const all = [
   "Collection",
@@ -14,36 +14,38 @@ const all = [
   "AnnotationCollection",
   "ContentResource",
   "Agent",
-];
+] as const;
 
-function getSupported(type: string) {
+export type AllResourceTypes = (typeof all)[number];
+
+function getSupported<const Type extends AllResourceTypes>(type: Type) {
   const required = [
-    ...(technicalProperties.required[(type || "ContentResource") as "Manifest"] || []),
-    ...(descriptiveProperties.required[(type || "ContentResource") as "Manifest"] || []),
-    ...(linkingProperties.required[(type || "ContentResource") as "Manifest"] || []),
-    ...(structuralProperties.required[(type || "ContentResource") as "Manifest"] || []),
-    ...(extensionProperties.required[(type || "ContentResource") as "Manifest"] || []),
+    ...(technicalProperties.required[type] || []),
+    ...(descriptiveProperties.required[type] || []),
+    ...(linkingProperties.required[type] || []),
+    ...(structuralProperties.required[type] || []),
+    ...(extensionProperties.required[type] || []),
   ];
   const recommended = [
-    ...(technicalProperties.recommended[(type || "ContentResource") as "Manifest"] || []),
-    ...(descriptiveProperties.recommended[(type || "ContentResource") as "Manifest"] || []),
-    ...(linkingProperties.recommended[(type || "ContentResource") as "Manifest"] || []),
-    ...(structuralProperties.recommended[(type || "ContentResource") as "Manifest"] || []),
-    ...(extensionProperties.recommended[(type || "ContentResource") as "Manifest"] || []),
+    ...(technicalProperties.recommended[type] || []),
+    ...(descriptiveProperties.recommended[type] || []),
+    ...(linkingProperties.recommended[type] || []),
+    ...(structuralProperties.recommended[type] || []),
+    ...(extensionProperties.recommended[type] || []),
   ];
   const notAllowed = [
-    ...(technicalProperties.notAllowed[(type || "ContentResource") as "Manifest"] || []),
-    ...(descriptiveProperties.notAllowed[(type || "ContentResource") as "Manifest"] || []),
-    ...(linkingProperties.notAllowed[(type || "ContentResource") as "Manifest"] || []),
-    ...(structuralProperties.notAllowed[(type || "ContentResource") as "Manifest"] || []),
-    ...(extensionProperties.notAllowed[(type || "ContentResource") as "Manifest"] || []),
+    ...(technicalProperties.notAllowed[type] || []),
+    ...(descriptiveProperties.notAllowed[type] || []),
+    ...(linkingProperties.notAllowed[type] || []),
+    ...(structuralProperties.notAllowed[type] || []),
+    ...(extensionProperties.notAllowed[type] || []),
   ];
   const optional = [
-    ...(technicalProperties.optional[(type || "ContentResource") as "Manifest"] || []),
-    ...(descriptiveProperties.optional[(type || "ContentResource") as "Manifest"] || []),
-    ...(linkingProperties.optional[(type || "ContentResource") as "Manifest"] || []),
-    ...(structuralProperties.optional[(type || "ContentResource") as "Manifest"] || []),
-    ...(extensionProperties.optional[(type || "ContentResource") as "Manifest"] || []),
+    ...(technicalProperties.optional[type] || []),
+    ...(descriptiveProperties.optional[type] || []),
+    ...(linkingProperties.optional[type] || []),
+    ...(structuralProperties.optional[type] || []),
+    ...(extensionProperties.optional[type] || []),
   ];
 
   const allowed = [...required, ...recommended, ...optional];

--- a/packages/editor-api/src/meta/rights.ts
+++ b/packages/editor-api/src/meta/rights.ts
@@ -16,7 +16,7 @@ const CC_BY_NC = "http://creativecommons.org/licenses/by-nc/4.0/";
 const CC_BY_NC_SA = "http://creativecommons.org/licenses/by-nc-sa/4.0/";
 const CC_BY_NC_ND = "http://creativecommons.org/licenses/by-nc-nd/4.0/";
 
-export const allRights = [CC0, CC_BY, CC_BY_SA, CC_BY_ND, CC_BY_NC, CC_BY_NC_SA, CC_BY_NC_ND];
+export const allRights = [CC0, CC_BY, CC_BY_SA, CC_BY_ND, CC_BY_NC, CC_BY_NC_SA, CC_BY_NC_ND] as const;
 
 export const creativeCommons: CCDefinition[] = [
   {

--- a/packages/editor-api/src/meta/structural.ts
+++ b/packages/editor-api/src/meta/structural.ts
@@ -1,30 +1,30 @@
-import { StructuralProperties } from "@iiif/presentation-3";
+import type { StructuralProperties } from "@iiif/presentation-3";
 
-const required: StructuralMap = {
+const required = {
   Collection: ["items"],
   Manifest: ["items"],
   Canvas: [],
-  Annotation: [],
+  Annotation: ["target"],
   AnnotationPage: [],
   Range: [],
   AnnotationCollection: [],
   ContentResource: [],
   Agent: [],
-} as const;
+} as const satisfies StructuralMap;
 
-const recommended: StructuralMap = {
+const recommended = {
   Collection: [],
   Manifest: [],
   Canvas: ["items"],
-  Annotation: [],
+  Annotation: ["body"],
   AnnotationPage: ["items"],
   Range: [],
   AnnotationCollection: [],
   ContentResource: [],
   Agent: [],
-} as const;
+} as const satisfies StructuralMap;
 
-const optional: StructuralMap = {
+const optional = {
   Collection: ["annotations"],
   Manifest: ["structures", "annotations"],
   Canvas: ["annotations"],
@@ -34,24 +34,26 @@ const optional: StructuralMap = {
   AnnotationCollection: [],
   ContentResource: ["annotations"],
   Agent: [],
-} as const;
+} as const satisfies StructuralMap;
 
-const notAllowed: StructuralMap = {
-  Collection: ["structures"],
-  Manifest: [],
-  Canvas: ["structures"],
+const notAllowed = {
+  Collection: ["structures", "target", "body"],
+  Manifest: ["target", "body"],
+  Canvas: ["structures", "target", "body"],
   Annotation: ["items", "structures", "annotations"],
-  AnnotationPage: ["structures", "annotations"],
-  Range: ["structures"],
+  AnnotationPage: ["structures", "annotations", "target", "body"],
+  Range: ["structures", "target", "body"],
   AnnotationCollection: [
     // Leaving this out, as it's technically valid - just not withing a Presentation 3 context.
     // "items",
     "structures",
     "annotations",
+    "target",
+    "body",
   ],
-  ContentResource: ["items", "structures"],
-  Agent: ["items", "structures", "annotations"],
-} as const;
+  ContentResource: ["items", "structures", "target", "body"],
+  Agent: ["items", "structures", "annotations", "target", "body"],
+} as const satisfies StructuralMap;
 
 type StructuralMap = Record<
   | "Collection"
@@ -63,10 +65,10 @@ type StructuralMap = Record<
   | "AnnotationCollection"
   | "ContentResource"
   | "Agent",
-  readonly (keyof StructuralProperties<unknown>)[]
+  readonly (keyof StructuralProperties<unknown> | "body" | "target")[]
 >;
 
-const all: readonly (keyof StructuralProperties<unknown>)[] = ["annotations", "items", "structures"] as const;
+const all = ["annotations", "items", "structures"] as const;
 
 export const structuralProperties = {
   all,

--- a/packages/editor-api/src/meta/technical.ts
+++ b/packages/editor-api/src/meta/technical.ts
@@ -1,6 +1,6 @@
-import { TechnicalProperties } from "@iiif/presentation-3";
+import type { TechnicalProperties } from "@iiif/presentation-3";
 
-const required: TechnicalMap = {
+const required = {
   Collection: ["id", "type"],
   Manifest: ["id", "type"],
   Canvas: ["id", "type"],
@@ -10,9 +10,9 @@ const required: TechnicalMap = {
   AnnotationCollection: ["id", "type"],
   ContentResource: ["id", "type"],
   Agent: ["id", "type"],
-} as const;
+} as const satisfies TechnicalMap;
 
-const recommended: TechnicalMap = {
+const recommended = {
   Collection: [],
   Manifest: [],
   Canvas: [],
@@ -22,9 +22,9 @@ const recommended: TechnicalMap = {
   AnnotationCollection: [],
   ContentResource: [],
   Agent: [],
-} as const;
+} as const satisfies TechnicalMap;
 
-const optional: TechnicalMap = {
+const optional = {
   Collection: ["viewingDirection", "behavior"],
   Manifest: ["viewingDirection", "behavior"],
   Canvas: ["height", "width", "duration", "behavior"],
@@ -34,11 +34,11 @@ const optional: TechnicalMap = {
   AnnotationCollection: ["behavior"],
   ContentResource: ["format", "height", "width", "duration", "behavior"],
   Agent: [],
-} as const;
+} as const satisfies TechnicalMap;
 
 const annotationOnly = ["motivation"] as const;
 
-const notAllowed: TechnicalMap = {
+const notAllowed = {
   Collection: ["format", "profile", "height", "width", "duration", "timeMode", ...annotationOnly],
   Manifest: ["format", "profile", "height", "width", "duration", "timeMode", ...annotationOnly],
   Canvas: ["format", "profile", "viewingDirection", "timeMode", ...annotationOnly],
@@ -76,7 +76,7 @@ const notAllowed: TechnicalMap = {
     "behavior",
     ...annotationOnly,
   ],
-} as const;
+} as const satisfies TechnicalMap;
 
 type TechnicalMap = Record<
   | "Collection"
@@ -91,7 +91,7 @@ type TechnicalMap = Record<
   readonly (keyof TechnicalProperties)[]
 >;
 
-const all: readonly (keyof TechnicalProperties)[] = [
+const all = [
   "id",
   "type",
   "format",

--- a/presets/collection-preset/src/preset.tsx
+++ b/presets/collection-preset/src/preset.tsx
@@ -5,8 +5,7 @@ import {
   manifestBrowserCreator,
   webPageCreator,
 } from "@manifest-editor/creators";
-import { allEditors, combinedProperties, metadata, useInStack } from "@manifest-editor/editors";
-import { descriptiveProperties, linkingProperties, technicalProperties } from "@manifest-editor/editors";
+import { allEditors, useInStack } from "@manifest-editor/editors";
 import { IIIFExplorer } from "@manifest-editor/iiif-browser";
 import {
   type Config,

--- a/presets/exhibition-preset/src/creators/image-browser-slide-creator.tsx
+++ b/presets/exhibition-preset/src/creators/image-browser-slide-creator.tsx
@@ -1,9 +1,4 @@
-import {
-  type CreatorFunctionContext,
-  creatorHelper,
-  defineCreator,
-  exampleFunction,
-} from "@manifest-editor/creator-api";
+import { type CreatorFunctionContext, creatorHelper, defineCreator } from "@manifest-editor/creator-api";
 import { type IIIFBrowserCreatorPayload, iiifBrowserCreator } from "@manifest-editor/creators";
 
 declare module "@manifest-editor/creator-api" {

--- a/presets/exhibition-preset/src/creators/image-service-slide-creator.tsx
+++ b/presets/exhibition-preset/src/creators/image-service-slide-creator.tsx
@@ -1,14 +1,16 @@
-import type {
-  CreatorDefinition,
-  CreatorFunctionContext,
-  GetCreatorPayload,
-} from "@manifest-editor/creator-api";
-import { imageServiceCreator } from "@manifest-editor/creators";
+import { type CreatorFunctionContext, creatorHelper, defineCreator } from "@manifest-editor/creator-api";
+import { type CreateImageServicePayload, imageServiceCreator } from "@manifest-editor/creators";
 import { imageSlideCreator } from "./image-slide-creator";
 
-export const imageServiceSlideCreator: CreatorDefinition<
-  GetCreatorPayload<typeof imageServiceCreator>
-> = {
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@exhibitions/image-service-creator": typeof imageServiceSlideCreator;
+    }
+  }
+}
+
+export const imageServiceSlideCreator = defineCreator({
   ...imageServiceCreator,
   id: "@exhibitions/image-service-creator",
   create: createImageService,
@@ -20,34 +22,30 @@ export const imageServiceSlideCreator: CreatorDefinition<
     parentTypes: ["Manifest"],
     parentFields: ["items"],
   },
-};
+});
 
-async function createImageService(
-  data: GetCreatorPayload<typeof imageServiceCreator>,
-  ctx: CreatorFunctionContext,
-) {
+async function createImageService(data: CreateImageServicePayload, ctx: CreatorFunctionContext) {
   const canvasId = ctx.generateId("canvas");
   const pageId = ctx.generateId("annotation-page", {
     id: canvasId,
     type: "Canvas",
   });
+  const annotationId = ctx.generateId("annotation");
+
+  const createImageService = creatorHelper(
+    ctx,
+    { id: annotationId, type: "Annotation" },
+    "body",
+    "@manifest-editor/image-service-creator",
+  );
 
   // 1. Call the original creator to get the annotation
-  const resource = await ctx.create<typeof imageServiceCreator>(
-    imageServiceCreator.id,
-    data,
-    {
-      target: {
-        id: canvasId,
-        type: "Canvas",
-      },
-      targetType: "Annotation",
-      parent: {
-        resource: { id: pageId, type: "AnnotationPage" },
-        property: "items",
-      },
+  const resource = await createImageService(data, {
+    target: {
+      id: canvasId,
+      type: "Canvas",
     },
-  );
+  });
 
   const { width, height } = resource.get();
 
@@ -63,7 +61,8 @@ async function createImageService(
   });
 
   // 2. Pass that to an empty slide.
-  return await ctx.create<typeof imageSlideCreator>(imageSlideCreator.id, {
+  const createSlide = creatorHelper(ctx, "Manifest", "items", "@exhibitions/image-slide-creator");
+  return await createSlide({
     canvasId,
     width,
     height,

--- a/presets/exhibition-preset/src/creators/image-slide-creator.tsx
+++ b/presets/exhibition-preset/src/creators/image-slide-creator.tsx
@@ -1,14 +1,20 @@
 import { emptyAnnotationPage, emptyCanvas } from "@iiif/parser";
 import type { InternationalString } from "@iiif/presentation-3";
 import { EmptyCanvasIcon } from "@manifest-editor/components";
-import type {
-  CreatorContext,
-  CreatorDefinition,
-  CreatorFunctionContext,
-  CreatorResource,
-} from "@manifest-editor/creator-api";
+import { type CreatorFunctionContext, type CreatorResource, defineCreator } from "@manifest-editor/creator-api";
 
-export const imageSlideCreator: CreatorDefinition<InfoBoxPayload> = {
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@exhibitions/image-slide-creator": typeof imageSlideCreator;
+      "@exhibitions/image-slide-creator-bottom": typeof imageSlideBottomCreator;
+      "@exhibitions/image-slide-creator-left": typeof imageSlideLeftCreator;
+      "@exhibitions/image-slide-creator-right": typeof imageSlideRightCreator;
+    }
+  }
+}
+
+export const imageSlideCreator = defineCreator({
   id: "@exhibitions/image-slide-creator",
   create: createImageSlide,
   label: "Empty slide",
@@ -21,36 +27,34 @@ export const imageSlideCreator: CreatorDefinition<InfoBoxPayload> = {
     parentTypes: ["Manifest"],
     parentFields: ["items"],
   },
-};
+});
 
-export const imageSlideLeftCreator: CreatorDefinition = {
+export const imageSlideLeftCreator = defineCreator({
   ...imageSlideCreator,
   id: "@exhibitions/image-slide-creator-left",
   label: "Image (Left)",
   summary: "An image with text on the left.",
   icon: <div>IMAGE (LEFT)</div>,
   create: (payload, ctx) => createImageSlide({ ...payload, type: "left" }, ctx),
-};
+});
 
-export const imageSlideRightCreator: CreatorDefinition = {
+export const imageSlideRightCreator = defineCreator({
   ...imageSlideCreator,
   id: "@exhibitions/image-slide-creator-right",
   label: "Image (Right)",
   summary: "An image with text on the right.",
   icon: <div>IMAGE (RIGHT)</div>,
-  create: (payload, ctx) =>
-    createImageSlide({ ...payload, type: "right" }, ctx),
-};
+  create: (payload, ctx) => createImageSlide({ ...payload, type: "right" }, ctx),
+});
 
-export const imageSlideBottomCreator: CreatorDefinition = {
+export const imageSlideBottomCreator = defineCreator({
   ...imageSlideCreator,
   id: "@exhibitions/image-slide-creator-bottom",
   label: "Image (Bottom)",
   summary: "An image with text at the bottom.",
   icon: <div>IMAGE (BOTTOM)</div>,
-  create: (payload, ctx) =>
-    createImageSlide({ ...payload, type: "bottom" }, ctx),
-};
+  create: (payload, ctx) => createImageSlide({ ...payload, type: "bottom" }, ctx),
+});
 
 interface InfoBoxPayload {
   canvasId?: string;
@@ -61,10 +65,7 @@ interface InfoBoxPayload {
   items?: CreatorResource[];
 }
 
-function createImageSlide(
-  payload: InfoBoxPayload,
-  ctx: CreatorFunctionContext,
-) {
+function createImageSlide(payload: InfoBoxPayload, ctx: CreatorFunctionContext) {
   const canvasId = payload.canvasId || ctx.generateId("Canvas");
   const itemsPageId = ctx.generateId("AnnotationPage", {
     id: canvasId,

--- a/presets/exhibition-preset/src/creators/image-url-slide.tsx
+++ b/presets/exhibition-preset/src/creators/image-url-slide.tsx
@@ -1,14 +1,15 @@
-import type {
-  CreatorDefinition,
-  CreatorFunctionContext,
-  GetCreatorPayload,
-} from "@manifest-editor/creator-api";
-import { imageUrlCreator } from "@manifest-editor/creators";
-import { imageSlideCreator } from "./image-slide-creator";
+import { type CreatorFunctionContext, creatorHelper, defineCreator } from "@manifest-editor/creator-api";
+import { type CreateImageUrlPayload, imageUrlCreator } from "@manifest-editor/creators";
 
-export const imageUrlSlideCreator: CreatorDefinition<
-  GetCreatorPayload<typeof imageUrlCreator>
-> = {
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@exhibitions/image-url-creator": typeof imageUrlSlideCreator;
+    }
+  }
+}
+
+export const imageUrlSlideCreator = defineCreator({
   ...imageUrlCreator,
   id: "@exhibitions/image-url-creator",
   create: createUrlSlide,
@@ -20,39 +21,36 @@ export const imageUrlSlideCreator: CreatorDefinition<
     parentTypes: ["Manifest"],
     parentFields: ["items"],
   },
-};
+});
 
-async function createUrlSlide(
-  data: GetCreatorPayload<typeof imageUrlCreator>,
-  ctx: CreatorFunctionContext,
-) {
+async function createUrlSlide(data: CreateImageUrlPayload, ctx: CreatorFunctionContext) {
   const canvasId = ctx.generateId("canvas");
   const pageId = ctx.generateId("annotation-page", {
     id: canvasId,
     type: "Canvas",
   });
+  const annotationId = ctx.generateId("annotation");
+
+  const createImageUrl = creatorHelper(
+    ctx,
+    { id: annotationId, type: "Annotation" },
+    "body",
+    "@manifest-editor/image-url-creator",
+  );
 
   // 1. Call the original creator to get the annotation
-  const resource = await ctx.create<typeof imageUrlCreator>(
-    imageUrlCreator.id,
-    data,
-    {
-      target: {
-        id: canvasId,
-        type: "Canvas",
-      },
-      targetType: "Annotation",
-      parent: {
-        resource: { id: pageId, type: "AnnotationPage" },
-        property: "items",
-      },
+  const resource = await createImageUrl(data, {
+    target: {
+      id: canvasId,
+      type: "Canvas",
     },
-  );
+    targetType: "Annotation",
+  });
 
   const { width, height } = resource.get();
 
   const annotation = ctx.embed({
-    id: ctx.generateId("annotation"),
+    id: annotationId,
     type: "Annotation",
     motivation: "painting",
     body: [resource],
@@ -63,7 +61,8 @@ async function createUrlSlide(
   });
 
   // 2. Pass that to an empty slide.
-  return await ctx.create<typeof imageSlideCreator>(imageSlideCreator.id, {
+  const createSlide = creatorHelper(ctx, "Manifest", "items", "@exhibitions/image-slide-creator");
+  return await createSlide({
     canvasId,
     width,
     height,

--- a/presets/exhibition-preset/src/creators/info-box-creator.tsx
+++ b/presets/exhibition-preset/src/creators/info-box-creator.tsx
@@ -1,22 +1,22 @@
 import { emptyAnnotation, emptyCanvas } from "@iiif/parser";
 import type { InternationalString } from "@iiif/presentation-3";
-import type {
-  CreatorDefinition,
-  CreatorFunctionContext,
-} from "@manifest-editor/creator-api";
+import { type CreatorFunctionContext, defineCreator } from "@manifest-editor/creator-api";
 
-export const infoBoxCreator: CreatorDefinition = {
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@exhibitions/info-box-creator": typeof infoBoxCreator;
+    }
+  }
+}
+
+export const infoBoxCreator = defineCreator({
   id: "@exhibitions/info-box-creator",
   create: createInfoBox,
   label: "Info box",
   summary: "A text panel for an exhibition",
   icon: (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="1em"
-      height="1em"
-      viewBox="0 0 24 24"
-    >
+    <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24">
       <title>Info box</title>
       <path
         fill="currentColor"
@@ -31,7 +31,7 @@ export const infoBoxCreator: CreatorDefinition = {
     parentTypes: ["Manifest"],
     parentFields: ["items"],
   },
-};
+});
 
 interface InfoBoxPayload {
   label?: InternationalString;
@@ -39,10 +39,7 @@ interface InfoBoxPayload {
   width?: number;
 }
 
-async function createInfoBox(
-  data: InfoBoxPayload,
-  ctx: CreatorFunctionContext,
-) {
+async function createInfoBox(data: InfoBoxPayload, ctx: CreatorFunctionContext) {
   const canvasId = ctx.generateId("canvas");
   const pageId = ctx.generateId("annotation-page", {
     id: canvasId,

--- a/presets/exhibition-preset/src/creators/youtube-slide-creator.tsx
+++ b/presets/exhibition-preset/src/creators/youtube-slide-creator.tsx
@@ -1,17 +1,25 @@
 import { emptyCanvas } from "@iiif/parser";
 import type { InternationalString } from "@iiif/presentation-3";
-import type { CreatorDefinition, CreatorFunctionContext } from "@manifest-editor/creator-api";
+import { type CreatorFunctionContext, defineCreator } from "@manifest-editor/creator-api";
 import { youTubeBodyCreator } from "@manifest-editor/creators";
 import { getYouTubeId } from "@manifest-editor/editors";
 
-export const youtubeSlideCreator: CreatorDefinition = {
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@exhibitions/youtube-creator": typeof youtubeSlideCreator;
+    }
+  }
+}
+
+export const youtubeSlideCreator = defineCreator({
   ...youTubeBodyCreator,
   id: "@exhibitions/youtube-creator",
   create: createYoutube,
   tags: ["video", "exhibition-slide"],
   label: "YouTube",
   summary: "A YouTube for an exhibition",
-};
+});
 
 interface YouTubeCreatePayload {
   youtubeUrl: string;


### PR DESCRIPTION
- new `defineCreator()` helper
- new global namespace for holding definitions: `IIIFManifestEditor.CreatorDefinitions`
- new helper for inferring types from definitions: `creatorHelper`


Essentially the new API makes the creators type-safe in 2 ways.

```ts
const helper = creatorHelper(ctx, "Canvas", "items", "...");
// Completions will be valid creators for the target  __^
```

For example, when you type:
```ts
const createSlide = creatorHelper(ctx, "Manifest", "items", "");
```
![image](https://github.com/user-attachments/assets/9ef41db4-7ab4-4220-9d3a-c22e87507c55)

You will see all the canvas creators.

Then once you select the creator, it will have the correct type information for the creator.
```
const createSlide = creatorHelper(ctx, "Manifest", "items", "@exhibitions/image-slide-creator");


await createSlide({ });
```