### PR TITLE
ICS-561 thumbnail image service canvas

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,7 +18,7 @@
     "@dnd-kit/sortable": "8.0.0",
     "@dnd-kit/utilities": "^3.2.1",
     "@iiif/helpers": "^1.3.1",
-    "@iiif/parser": "^2.1.7",
+    "@iiif/parser": "^2.1.8",
     "@iiif/presentation-3": "^2.2.3",
     "@iiif/presentation-3-normalized": "^0.9.7",
     "@manifest-editor/collection-preset": "workspace:*",

--- a/packages/components/src/icons/ScaledImageIcon.tsx
+++ b/packages/components/src/icons/ScaledImageIcon.tsx
@@ -1,0 +1,13 @@
+import type { SVGProps } from "react";
+
+export function ScaledImageIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" {...props}>
+      {/* Icon from Google Material Icons by Material Design Authors - https://github.com/material-icons/material-icons/blob/master/LICENSE */}
+      <path
+        fill="currentColor"
+        d="M21 15h2v2h-2zm0-4h2v2h-2zm2 8h-2v2c1 0 2-1 2-2M13 3h2v2h-2zm8 4h2v2h-2zm0-4v2h2c0-1-1-2-2-2M1 7h2v2H1zm16-4h2v2h-2zm0 16h2v2h-2zM3 3C2 3 1 4 1 5h2zm6 0h2v2H9zM5 3h2v2H5zm-4 8v8c0 1.1.9 2 2 2h12V11zm2 8l2.5-3.21l1.79 2.15l2.5-3.22L13 19z"
+      />
+    </svg>
+  );
+}

--- a/packages/components/src/index.tsx
+++ b/packages/components/src/index.tsx
@@ -58,6 +58,7 @@ export * from "./icons/PreviewIcon";
 export * from "./icons/ImageListIcon";
 export * from "./icons/BackIcon";
 export * from "./icons/GridIcon";
+export * from "./icons/ScaledImageIcon";
 
 // Messages
 export * from "./ErrorMessage";

--- a/packages/creator-api/package.json
+++ b/packages/creator-api/package.json
@@ -11,17 +11,11 @@
   "engines": {
     "node": ">=18.14.1"
   },
-  "keywords": [
-    "iiif",
-    "editor",
-    "typescript"
-  ],
+  "keywords": ["iiif", "editor", "typescript"],
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "exports": {
     ".": {
       "import": {
@@ -43,7 +37,7 @@
   },
   "dependencies": {
     "@iiif/helpers": "^1.3.1",
-    "@iiif/parser": "^2.1.7",
+    "@iiif/parser": "^2.1.8",
     "@iiif/presentation-3": "^2.2.3",
     "@iiif/presentation-3-normalized": "^0.9.7",
     "@manifest-editor/editor-api": "workspace:*",

--- a/packages/creators/package.json
+++ b/packages/creators/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@atlas-viewer/iiif-image-api": "^2.2.0",
     "@iiif/helpers": "^1.3.1",
-    "@iiif/parser": "^2.1.7",
+    "@iiif/parser": "^2.1.8",
     "@iiif/presentation-3": "^2.2.3",
     "@iiif/presentation-3-normalized": "^0.9.7",
     "@manifest-editor/components": "workspace:*",

--- a/packages/creators/src/ContentResource/ImageServiceCreator/create-image-service.tsx
+++ b/packages/creators/src/ContentResource/ImageServiceCreator/create-image-service.tsx
@@ -57,8 +57,6 @@ export async function createImageServer(data: CreateImageServicePayload, ctx: Cr
     originalPath: (request as any).originalPath,
   });
 
-  console.log(imageId);
-
   const resource = ctx.embed({
     id: imageId,
     type: "Image",

--- a/packages/creators/src/ContentResource/ImageServiceCreator/index.tsx
+++ b/packages/creators/src/ContentResource/ImageServiceCreator/index.tsx
@@ -1,5 +1,5 @@
+import { IIIFLogo } from "@manifest-editor/components";
 import { defineCreator } from "@manifest-editor/creator-api";
-import { TextFormatIcon } from "@manifest-editor/ui/icons/TextFormatIcon";
 import { CreateImageServerForm, createImageServer } from "./create-image-service";
 
 declare module "@manifest-editor/creator-api" {
@@ -15,7 +15,7 @@ export const imageServiceCreator = defineCreator({
   create: createImageServer,
   label: "Image Service",
   summary: "Add an image from Image Service",
-  icon: <TextFormatIcon />,
+  icon: <IIIFLogo style={{ padding: 10 }} />,
   render(ctx) {
     return <CreateImageServerForm {...ctx} />;
   },

--- a/packages/creators/src/ContentResource/ThumbnailCreator/create-thumbnail.tsx
+++ b/packages/creators/src/ContentResource/ThumbnailCreator/create-thumbnail.tsx
@@ -1,0 +1,173 @@
+import type { ImageService } from "@iiif/presentation-3";
+import { ActionButton } from "@manifest-editor/components";
+import type { CreatorContext, CreatorFunctionContext, CreatorResource } from "@manifest-editor/creator-api";
+import { Input, InputContainer, InputLabel } from "@manifest-editor/editors";
+import { PaddedSidebarContainer } from "@manifest-editor/ui/atoms/PaddedSidebarContainer";
+import { type FormEvent, useMemo, useState } from "react";
+import { getCanonicalUrl, serviceImageAtSize } from "./thumbnail-helpers";
+
+export interface CreateThumbnailPayload {
+  service: ImageService;
+  thumbnailUrl?: string;
+  width: number;
+  height?: number;
+}
+
+export async function createThumbnail(data: CreateThumbnailPayload, ctx: CreatorFunctionContext) {
+  // Here is where we can add a thumbnail, if appropriate.
+  const service = { ...data.service };
+  const sizes = service.sizes;
+  if (service["@id"]) {
+    service.id = service["@id"];
+  }
+  if (service["@type"]) {
+    service.type = service["@type"];
+  }
+
+  if (data.thumbnailUrl) {
+    return ctx.embed({
+      id: data.thumbnailUrl,
+      type: "Image",
+      format: "image/jpeg",
+      width: data.width,
+      height: data.height,
+    });
+  }
+
+  if (sizes) {
+    const thumbnailSize = data.width || 400;
+    // We have something to work with for a thumbnail - could be improved to listen to height/width.
+    let bestMatch: { width: number; height?: number } | null = null;
+    for (const size of sizes) {
+      if (!bestMatch || Math.abs(size.width - thumbnailSize) < Math.abs(bestMatch.width - thumbnailSize)) {
+        bestMatch = { width: size.width, height: size.height };
+      }
+    }
+    if (bestMatch) {
+      const imageId = serviceImageAtSize(service, bestMatch);
+
+      return ctx.embed({
+        id: imageId,
+        type: "Image",
+        format: "image/jpeg",
+        width: bestMatch.width,
+        height: bestMatch.height,
+      });
+    }
+  }
+
+  // Otherwise we have nothing..
+  return null;
+}
+
+// @todo cover a lot more things - like offering size dropdown.
+export function CreateThumbnailForm(props: CreatorContext) {
+  const [url, setUrl] = useState("");
+  const [service, setService] = useState<ImageService | null>(null);
+  const [selectedSize, setSelectedSize] = useState({ width: 0, height: 0 });
+  const previewUrl = useMemo(() => {
+    if (!service) return null;
+    if (!selectedSize.width || !selectedSize.height) return null;
+
+    return serviceImageAtSize(service, selectedSize);
+  }, [selectedSize, service]);
+
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const data = new FormData(e.target as HTMLFormElement);
+    const formData = Object.fromEntries(data.entries()) as any;
+
+    const url = formData.url;
+
+    if (url) {
+      const info = getCanonicalUrl(url);
+
+      if (!info) {
+        throw new Error("Invalid image service request");
+      }
+
+      fetch(info)
+        .then((r) => r.json())
+        .then((service) => {
+          setService(service);
+          const size0 = service.sizes?.[0];
+          if (size0) {
+            setSelectedSize(size0);
+          }
+        });
+    }
+  };
+
+  // https://dlcs.digirati.io/iiif-img/58/2/20-carina_nebula~orig.png
+
+  if (service) {
+    return (
+      <PaddedSidebarContainer>
+        <div className="mb-4">
+          <div className="mb-2">{service["@id"] || service.id}</div>
+          <div className="flex gap-2 mb-4">
+            {service.sizes?.map((size) => {
+              const isSelected = size.width === selectedSize.width;
+              return (
+                <ActionButton
+                  key={size.width}
+                  primary={isSelected}
+                  isDisabled={isSelected}
+                  large
+                  onPress={() => setSelectedSize(size)}
+                >
+                  {size.width}x{size.height}
+                </ActionButton>
+              );
+            })}
+          </div>
+
+          {previewUrl ? <img src={previewUrl} alt="preview of selected resource" /> : null}
+        </div>
+
+        <ActionButton
+          primary
+          large
+          isDisabled={!previewUrl}
+          onPress={() => {
+            if (!service) return;
+            props.runCreate({ service, width: selectedSize.width, height: selectedSize.height });
+          }}
+        >
+          Add thumbnail
+        </ActionButton>
+      </PaddedSidebarContainer>
+    );
+  }
+
+  return (
+    <PaddedSidebarContainer>
+      <form onSubmit={onSubmit}>
+        <div className="flex gap-2 items-center">
+          <InputContainer $wide>
+            <InputLabel htmlFor="id">Link to image service</InputLabel>
+            <Input
+              id="url"
+              name="url"
+              defaultValue=""
+              onPaste={(e) => {
+                const text = e.clipboardData.getData("text/plain");
+                setUrl(text ? getCanonicalUrl(text) : "");
+              }}
+              onBlur={(e) => setUrl(e.currentTarget.value ? getCanonicalUrl(e.currentTarget.value) : "")}
+            />
+          </InputContainer>
+        </div>
+        <div>
+          <ActionButton primary large type="submit" isDisabled={!url}>
+            Select size
+          </ActionButton>
+        </div>
+      </form>
+    </PaddedSidebarContainer>
+  );
+}
+
+function ImageSelectionPreview({ url }: { url: string }) {
+  return null;
+}

--- a/packages/creators/src/ContentResource/ThumbnailCreator/index.tsx
+++ b/packages/creators/src/ContentResource/ThumbnailCreator/index.tsx
@@ -1,0 +1,27 @@
+import { ScaledImageIcon } from "@manifest-editor/components";
+import { defineCreator } from "@manifest-editor/creator-api";
+import { CreateThumbnailForm, createThumbnail } from "./create-thumbnail";
+
+declare module "@manifest-editor/creator-api" {
+  namespace IIIFManifestEditor {
+    interface CreatorDefinitions {
+      "@manifest-editor/thumbnail-image": typeof thumbnailCreator;
+    }
+  }
+}
+
+export const thumbnailCreator = defineCreator({
+  id: "@manifest-editor/thumbnail-image",
+  create: createThumbnail,
+  label: "Thumbnail from service",
+  summary: "Add thumbnail from an image service",
+  icon: <ScaledImageIcon />,
+  render(ctx) {
+    return <CreateThumbnailForm {...ctx} />;
+  },
+  resourceType: "ContentResource",
+  resourceFields: ["id", "type", "format"],
+  supports: {
+    parentFields: ["thumbnail"],
+  },
+});

--- a/packages/creators/src/ContentResource/ThumbnailCreator/thumbnail-helpers.ts
+++ b/packages/creators/src/ContentResource/ThumbnailCreator/thumbnail-helpers.ts
@@ -1,0 +1,47 @@
+import {
+  canonicalServiceUrl,
+  createImageServiceRequest,
+  imageServiceRequestToString,
+  parseImageServiceRequest,
+} from "@iiif/parser/image-3";
+import type { ImageService } from "@iiif/presentation-3";
+
+export function serviceImageAtSize(service: ImageService, size: { width: number; height?: number }) {
+  if (service["@id"]) {
+    service.id = service["@id"];
+  }
+  if (service["@type"]) {
+    service.type = service["@type"];
+  }
+  const request = createImageServiceRequest(service);
+  return imageServiceRequestToString({
+    identifier: request.identifier,
+    server: request.server,
+    scheme: request.scheme,
+    type: "image",
+    size: {
+      max: false,
+      confined: false,
+      upscaled: false,
+      width: size.width,
+      height: size.height,
+    },
+    format: "jpg",
+    // This isn't how it should be modelled, always full,
+    // region: data.selector ? data.selector : { full: true },
+    region: { full: true },
+    rotation: { angle: 0 },
+    quality: "default",
+    prefix: request.prefix,
+    originalPath: (request as any).originalPath,
+  });
+}
+
+export function getCanonicalUrl(url: string) {
+  return url.endsWith("default.jpg")
+    ? imageServiceRequestToString({
+        ...parseImageServiceRequest(url),
+        type: "info",
+      })
+    : canonicalServiceUrl(url);
+}

--- a/packages/creators/src/index.ts
+++ b/packages/creators/src/index.ts
@@ -15,6 +15,7 @@ import { imageServiceCreator } from "./ContentResource/ImageServiceCreator";
 import { imageUrlCreator } from "./ContentResource/ImageUrlCreator";
 import { imageUrlListCreator } from "./ContentResource/ImageUrlListCreator";
 import { plaintextCreator } from "./ContentResource/PlaintextCreator";
+import { thumbnailCreator } from "./ContentResource/ThumbnailCreator";
 import { webPageCreator } from "./ContentResource/WebPageCreator";
 import { youTubeBodyCreator } from "./ContentResource/YouTubeCreator";
 import { manifestBrowserCreator } from "./Manifest/ManifestBrowserCreator";
@@ -34,6 +35,7 @@ export * from "./ContentResource/ImageServiceCreator/create-image-service";
 export * from "./ContentResource/ImageUrlCreator/create-image-url";
 export * from "./ContentResource/ImageUrlListCreator/create-image-url-list";
 export * from "./ContentResource/PlaintextCreator/create-plaintext";
+export * from "./ContentResource/ThumbnailCreator/create-thumbnail";
 export * from "./ContentResource/WebPageCreator/create-web-page";
 export * from "./ContentResource/YouTubeCreator/create-youtube-body";
 export * from "./Manifest/ManifestBrowserCreator/manifest-browser-creator";
@@ -59,6 +61,7 @@ export const allCreators = [
   captionedImageAnnotation,
   imageUrlListCreator,
   imageUrlListAnnotation,
+  thumbnailCreator,
 ];
 
 export {

--- a/packages/editor-api/package.json
+++ b/packages/editor-api/package.json
@@ -11,17 +11,11 @@
   "engines": {
     "node": ">=18.14.1"
   },
-  "keywords": [
-    "iiif",
-    "editor",
-    "typescript"
-  ],
+  "keywords": ["iiif", "editor", "typescript"],
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "exports": {
     ".": {
       "import": {
@@ -43,7 +37,7 @@
   },
   "dependencies": {
     "@iiif/helpers": "^1.3.1",
-    "@iiif/parser": "^2.1.7",
+    "@iiif/parser": "^2.1.8",
     "@iiif/presentation-3": "^2.2.3",
     "@iiif/presentation-3-normalized": "^0.9.7",
     "polygon-editor": "^0.0.6"

--- a/packages/editors/package.json
+++ b/packages/editors/package.json
@@ -45,7 +45,7 @@
     "@dnd-kit/utilities": "^3.2.1",
     "@floating-ui/react": "^0.26.13",
     "@iiif/helpers": "^1.3.1",
-    "@iiif/parser": "^2.1.7",
+    "@iiif/parser": "^2.1.8",
     "@iiif/presentation-3": "^2.2.3",
     "@iiif/presentation-3-normalized": "^0.9.7",
     "@manifest-editor/components": "workspace:*",

--- a/packages/iiif-browser/package.json
+++ b/packages/iiif-browser/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@atlas-viewer/atlas": "^2.0.6",
     "@iiif/helpers": "^1.3.1",
-    "@iiif/parser": "^2.1.7",
+    "@iiif/parser": "^2.1.8",
     "@iiif/presentation-3": "^2.2.3",
     "@iiif/presentation-3-normalized": "^0.9.7",
     "react": "^18.3.1",

--- a/packages/manifest-editor/package.json
+++ b/packages/manifest-editor/package.json
@@ -11,18 +11,11 @@
   "engines": {
     "node": ">=18.14.1"
   },
-  "keywords": [
-    "iiif",
-    "editor",
-    "typescript"
-  ],
+  "keywords": ["iiif", "editor", "typescript"],
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": [
-    "dist",
-    "reset.css"
-  ],
+  "files": ["dist", "reset.css"],
   "exports": {
     ".": {
       "import": {
@@ -46,7 +39,7 @@
   },
   "dependencies": {
     "@iiif/helpers": "^1.3.1",
-    "@iiif/parser": "^2.1.7",
+    "@iiif/parser": "^2.1.8",
     "@iiif/presentation-3": "^2.2.3",
     "@iiif/presentation-3-normalized": "^0.9.7",
     "@manifest-editor/collection-preset": "workspace:*",

--- a/packages/projects/package.json
+++ b/packages/projects/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@iiif/helpers": "^1.3.1",
-    "@iiif/parser": "^2.1.7",
+    "@iiif/parser": "^2.1.8",
     "@iiif/presentation-3": "^2.2.3",
     "@iiif/presentation-3-normalized": "^0.9.7",
     "@manifest-editor/client-vault": "workspace:*",

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -35,7 +35,7 @@
     "@atlas-viewer/iiif-image-api": "^2.2.0",
     "@floating-ui/react": "^0.26.13",
     "@iiif/helpers": "^1.3.1",
-    "@iiif/parser": "^2.1.7",
+    "@iiif/parser": "^2.1.8",
     "@iiif/presentation-3": "^2.2.3",
     "@iiif/presentation-3-normalized": "^0.9.7",
     "@manifest-editor/client-vault": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,10 +104,10 @@ importers:
         version: 3.2.2(react@18.3.1)
       '@iiif/helpers':
         specifier: ^1.3.1
-        version: 1.3.1(@iiif/parser@2.1.7)
+        version: 1.3.1(@iiif/parser@2.1.8)
       '@iiif/parser':
-        specifier: ^2.1.7
-        version: 2.1.7
+        specifier: ^2.1.8
+        version: 2.1.8
       '@iiif/presentation-3':
         specifier: ^2.2.3
         version: 2.2.3
@@ -451,10 +451,10 @@ importers:
     dependencies:
       '@iiif/helpers':
         specifier: ^1.3.1
-        version: 1.3.1(@iiif/parser@2.1.7)
+        version: 1.3.1(@iiif/parser@2.1.8)
       '@iiif/parser':
-        specifier: ^2.1.7
-        version: 2.1.7
+        specifier: ^2.1.8
+        version: 2.1.8
       '@iiif/presentation-3':
         specifier: ^2.2.3
         version: 2.2.3
@@ -491,10 +491,10 @@ importers:
         version: 2.2.0
       '@iiif/helpers':
         specifier: ^1.3.1
-        version: 1.3.1(@iiif/parser@2.1.7)
+        version: 1.3.1(@iiif/parser@2.1.8)
       '@iiif/parser':
-        specifier: ^2.1.7
-        version: 2.1.7
+        specifier: ^2.1.8
+        version: 2.1.8
       '@iiif/presentation-3':
         specifier: ^2.2.3
         version: 2.2.3
@@ -561,10 +561,10 @@ importers:
     dependencies:
       '@iiif/helpers':
         specifier: ^1.3.1
-        version: 1.3.1(@iiif/parser@2.1.7)
+        version: 1.3.1(@iiif/parser@2.1.8)
       '@iiif/parser':
-        specifier: ^2.1.7
-        version: 2.1.7
+        specifier: ^2.1.8
+        version: 2.1.8
       '@iiif/presentation-3':
         specifier: ^2.2.3
         version: 2.2.3
@@ -610,10 +610,10 @@ importers:
         version: 0.26.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@iiif/helpers':
         specifier: ^1.3.1
-        version: 1.3.1(@iiif/parser@2.1.7)
+        version: 1.3.1(@iiif/parser@2.1.8)
       '@iiif/parser':
-        specifier: ^2.1.7
-        version: 2.1.7
+        specifier: ^2.1.8
+        version: 2.1.8
       '@iiif/presentation-3':
         specifier: ^2.2.3
         version: 2.2.3
@@ -770,10 +770,10 @@ importers:
         version: 2.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@iiif/helpers':
         specifier: ^1.3.1
-        version: 1.3.1(@iiif/parser@2.1.7)
+        version: 1.3.1(@iiif/parser@2.1.8)
       '@iiif/parser':
-        specifier: ^2.1.7
-        version: 2.1.7
+        specifier: ^2.1.8
+        version: 2.1.8
       '@iiif/presentation-3':
         specifier: ^2.2.3
         version: 2.2.3
@@ -878,10 +878,10 @@ importers:
     dependencies:
       '@iiif/helpers':
         specifier: ^1.3.1
-        version: 1.3.1(@iiif/parser@2.1.7)
+        version: 1.3.1(@iiif/parser@2.1.8)
       '@iiif/parser':
-        specifier: ^2.1.7
-        version: 2.1.7
+        specifier: ^2.1.8
+        version: 2.1.8
       '@iiif/presentation-3':
         specifier: ^2.2.3
         version: 2.2.3
@@ -957,10 +957,10 @@ importers:
     dependencies:
       '@iiif/helpers':
         specifier: ^1.3.1
-        version: 1.3.1(@iiif/parser@2.1.7)
+        version: 1.3.1(@iiif/parser@2.1.8)
       '@iiif/parser':
-        specifier: ^2.1.7
-        version: 2.1.7
+        specifier: ^2.1.8
+        version: 2.1.8
       '@iiif/presentation-3':
         specifier: ^2.2.3
         version: 2.2.3
@@ -1070,10 +1070,10 @@ importers:
         version: 0.26.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@iiif/helpers':
         specifier: ^1.3.1
-        version: 1.3.1(@iiif/parser@2.1.7)
+        version: 1.3.1(@iiif/parser@2.1.8)
       '@iiif/parser':
-        specifier: ^2.1.7
-        version: 2.1.7
+        specifier: ^2.1.8
+        version: 2.1.8
       '@iiif/presentation-3':
         specifier: ^2.2.3
         version: 2.2.3
@@ -1225,10 +1225,10 @@ importers:
     dependencies:
       '@iiif/helpers':
         specifier: ^1.3.1
-        version: 1.3.1(@iiif/parser@2.1.7)
+        version: 1.3.1(@iiif/parser@2.1.8)
       '@iiif/parser':
-        specifier: ^2.1.7
-        version: 2.1.7
+        specifier: ^2.1.8
+        version: 2.1.8
       '@iiif/presentation-3':
         specifier: ^2.2.3
         version: 2.2.3
@@ -1301,10 +1301,10 @@ importers:
         version: 3.2.2(react@18.3.1)
       '@iiif/helpers':
         specifier: ^1.3.1
-        version: 1.3.1(@iiif/parser@2.1.7)
+        version: 1.3.1(@iiif/parser@2.1.8)
       '@iiif/parser':
-        specifier: ^2.1.7
-        version: 2.1.7
+        specifier: ^2.1.8
+        version: 2.1.8
       '@iiif/presentation-3':
         specifier: ^2.2.3
         version: 2.2.3
@@ -1374,10 +1374,10 @@ importers:
     dependencies:
       '@iiif/helpers':
         specifier: ^1.3.1
-        version: 1.3.1(@iiif/parser@2.1.7)
+        version: 1.3.1(@iiif/parser@2.1.8)
       '@iiif/parser':
-        specifier: ^2.1.7
-        version: 2.1.7
+        specifier: ^2.1.8
+        version: 2.1.8
       '@iiif/presentation-3':
         specifier: ^2.2.3
         version: 2.2.3
@@ -2890,9 +2890,6 @@ packages:
     resolution: {integrity: sha512-zVqgvvrUhKVq8JR1Gz8VXp+dD3SDdleAg/yJfGJ7cFvqFXiNQRtgY1ZbKxUfj/5ej5w5pgD/UuFF+E2CjcbxwQ==}
     peerDependencies:
       '@iiif/parser': ^2.1.7
-
-  '@iiif/parser@2.1.7':
-    resolution: {integrity: sha512-a3NrHOdW6RbmUeBCFJ751FBBuzS251O7owbRjUHUvRRs9GoFwNIDk5slh9qP5FFHycIbuyWjyl1lIxbikxAq/g==}
 
   '@iiif/parser@2.1.8':
     resolution: {integrity: sha512-87ifvY3Pq6dzSbHKrCr6/aIiZZDeaozIFz+EAYWYGxmpxn213t3kISCrSCC/XJ03jdXW7mQgPUEPcmztX5uh1A==}
@@ -14296,18 +14293,6 @@ snapshots:
       parse-svg-path: 0.1.2
       svg-arc-to-cubic-bezier: 3.2.0
 
-  '@iiif/helpers@1.3.1(@iiif/parser@2.1.7)':
-    dependencies:
-      '@iiif/parser': 2.1.7
-      '@iiif/presentation-2': 1.0.4(@iiif/presentation-3@2.2.3)
-      '@iiif/presentation-3': 2.2.3
-      '@iiif/presentation-3-normalized': 0.9.7
-      '@types/geojson': 7946.0.13
-    optionalDependencies:
-      abs-svg-path: 0.1.1
-      parse-svg-path: 0.1.2
-      svg-arc-to-cubic-bezier: 3.2.0
-
   '@iiif/helpers@1.3.1(@iiif/parser@2.1.8)':
     dependencies:
       '@iiif/parser': 2.1.8
@@ -14319,13 +14304,6 @@ snapshots:
       abs-svg-path: 0.1.1
       parse-svg-path: 0.1.2
       svg-arc-to-cubic-bezier: 3.2.0
-
-  '@iiif/parser@2.1.7':
-    dependencies:
-      '@iiif/presentation-2': 1.0.4(@iiif/presentation-3@2.2.3)
-      '@iiif/presentation-3': 2.2.3
-      '@iiif/presentation-3-normalized': 0.9.7
-      '@types/geojson': 7946.0.14
 
   '@iiif/parser@2.1.8':
     dependencies:
@@ -21010,8 +20988,8 @@ snapshots:
   iiif-browser@2.0.1(@types/react@18.3.3)(immer@10.1.1):
     dependencies:
       '@atlas-viewer/atlas': 2.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@iiif/helpers': 1.3.1(@iiif/parser@2.1.7)
-      '@iiif/parser': 2.1.7
+      '@iiif/helpers': 1.3.1(@iiif/parser@2.1.8)
+      '@iiif/parser': 2.1.8
       '@iiif/presentation-3': 2.2.3
       '@iiif/presentation-3-normalized': 0.9.7
       history: 5.3.0
@@ -23806,8 +23784,8 @@ snapshots:
     dependencies:
       '@atlas-viewer/atlas': 2.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@atlas-viewer/iiif-image-api': 2.2.0
-      '@iiif/helpers': 1.3.1(@iiif/parser@2.1.7)
-      '@iiif/parser': 2.1.7
+      '@iiif/helpers': 1.3.1(@iiif/parser@2.1.8)
+      '@iiif/parser': 2.1.8
       '@iiif/presentation-2': 1.0.4(@iiif/presentation-3@2.2.3)
       '@iiif/presentation-3': 2.2.3
       '@iiif/presentation-3-normalized': 0.9.7

--- a/presets/collection-preset/package.json
+++ b/presets/collection-preset/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@iiif/helpers": "^1.3.1",
-    "@iiif/parser": "^2.1.7",
+    "@iiif/parser": "^2.1.8",
     "@iiif/presentation-3": "^2.2.3",
     "@iiif/presentation-3-normalized": "^0.9.7",
     "@manifest-editor/components": "workspace:*",

--- a/presets/exhibition-preset/package.json
+++ b/presets/exhibition-preset/package.json
@@ -41,7 +41,7 @@
     "@dnd-kit/sortable": "8.0.0",
     "@dnd-kit/utilities": "^3.2.1",
     "@iiif/helpers": "^1.3.1",
-    "@iiif/parser": "^2.1.7",
+    "@iiif/parser": "^2.1.8",
     "@iiif/presentation-3": "^2.2.3",
     "@iiif/presentation-3-normalized": "^0.9.7",
     "@manifest-editor/components": "workspace:*",

--- a/presets/manifest-preset/package.json
+++ b/presets/manifest-preset/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@iiif/helpers": "^1.3.1",
-    "@iiif/parser": "^2.1.7",
+    "@iiif/parser": "^2.1.8",
     "@iiif/presentation-3": "^2.2.3",
     "@iiif/presentation-3-normalized": "^0.9.7",
     "@manifest-editor/components": "workspace:*",


### PR DESCRIPTION
This PR add a new creator for creating thumbnails from an image service. We needed it as part of another creator (image service url, when creating a canvas) but it can also be used standalone.

The standalone creator is set up only for the thumbnail field.
![image](https://github.com/user-attachments/assets/fea3e029-3d2b-4222-a67e-12918a6e7af1)

When you open it, you get to choose the size (only if the image service supports it).
![image](https://github.com/user-attachments/assets/43ca4055-bc2d-478c-8304-a5ddbc71fcfc)

Once you paste in an image service, you can then select a size:
![image](https://github.com/user-attachments/assets/ca7ba92a-6ab1-45a2-b8cb-92c6aa37b2a9)

The creator can be called programatically too:
```ts
const createThumbnail = creatorHelper(ctx, "Canvas", "thumbnail", "@manifest-editor/thumbnail-image");
const thumbnail = await createThumbnail({
  service: data.service, // fetched image service.
  width: data.thumbnailSize || 400, // a closest size.
});
```
