### PR TITLE
Prepare Manifest Editor 2.2.0 fixes

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Nextra docs starter with search included.",
   "private": true,
   "scripts": {

--- a/apps/vite-example/package.json
+++ b/apps/vite-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite-example",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3008",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/@lerna-lite/cli/schemas/lerna-schema.json",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "npmClient": "pnpm",
   "packages": [
     "packages/*",

--- a/packages/client-vault/package.json
+++ b/packages/client-vault/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifest-editor/client-vault",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "bugs": "https://github.com/digirati-co-uk/iiif-manifest-editor/issues",
   "repository": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifest-editor/components",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "bugs": "https://github.com/digirati-co-uk/iiif-manifest-editor/issues",
   "repository": {

--- a/packages/components/src/LazyThumbnail.tsx
+++ b/packages/components/src/LazyThumbnail.tsx
@@ -1,7 +1,21 @@
-import { type BoxSelector, createThumbnailHelper, type FixedSizeImage, type TemporalBoxSelector } from "@iiif/helpers";
+import {
+  type BoxSelector,
+  createPaintingAnnotationsHelper,
+  createThumbnailHelper,
+  expandTarget,
+  type FixedSizeImage,
+  type TemporalBoxSelector,
+} from "@iiif/helpers";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
-import { useCanvas, useRenderingStrategy, useThumbnail, useVault } from "react-iiif-vault";
+import {
+  getRenderingStrategy,
+  useCanvas,
+  useLoadImageService,
+  usePaintingAnnotations,
+  useThumbnail,
+  useVault,
+} from "react-iiif-vault";
 import { LazyLoadComponent } from "react-lazy-load-image-component";
 import { twMerge } from "tailwind-merge";
 import { TextIcon } from "./icons/TextIcon";
@@ -35,6 +49,37 @@ export function LazyThumbnail({
 }
 
 const renderCache = new Map<string, string>();
+
+export function paintingAnnotationTargetsCanvas(annotation: any, canvasId?: string) {
+  return !!canvasId && expandTarget(annotation.target).source.id === canvasId;
+}
+
+export function useCanvasRenderingStrategy() {
+  const canvas = useCanvas();
+  const vault = useVault();
+  const annotations = usePaintingAnnotations();
+  const [loadImageService] = useLoadImageService();
+  const helper = useMemo(() => createPaintingAnnotationsHelper(vault), [vault]);
+  const paintables = useMemo(
+    () =>
+      helper.getPaintables(
+        annotations.filter((annotation) => paintingAnnotationTargetsCanvas(annotation, canvas?.id)),
+      ),
+    [annotations, canvas?.id, helper],
+  );
+
+  return useMemo(
+    () =>
+      getRenderingStrategy({
+        canvas,
+        paintables,
+        supports: ["empty", "images", "media", "textual-content", "complex-timeline"],
+        loadImageService,
+        vault,
+      }),
+    [canvas, loadImageService, paintables, vault],
+  );
+}
 
 export function getImageApiRegion(resource: any) {
   const selector = resource?.selector;
@@ -128,7 +173,7 @@ function LazyThumbnailOuter({
   region?: ThumbnailRegion;
   singleImage?: boolean;
 }) {
-  const [strategy] = useRenderingStrategy();
+  const strategy = useCanvasRenderingStrategy();
   const vault = useVault();
   const useComplexThumbnail = shouldUseComplexCanvasThumbnail(
     strategy,
@@ -221,7 +266,7 @@ function LazyThumbnailInner({ cover, fade = true }: { cover?: boolean; fade?: bo
 }
 
 function ThumbnailFallback() {
-  const [strategy] = useRenderingStrategy();
+  const strategy = useCanvasRenderingStrategy();
 
   if (strategy.type === "textual-content") {
     return (
@@ -271,7 +316,7 @@ function ComplexCanvasThumbnail({
   singleImage?: boolean;
 }) {
   const canvas = useCanvas();
-  const [strategy] = useRenderingStrategy();
+  const strategy = useCanvasRenderingStrategy();
   const vault = useVault();
   const helper = useMemo(() => {
     return createThumbnailHelper(vault);

--- a/packages/creator-api/package.json
+++ b/packages/creator-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifest-editor/creator-api",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "bugs": "https://github.com/digirati-co-uk/iiif-manifest-editor/issues",
   "repository": {

--- a/packages/creators/package.json
+++ b/packages/creators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifest-editor/creators",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "bugs": "https://github.com/digirati-co-uk/iiif-manifest-editor/issues",
   "repository": {

--- a/packages/creators/src/ContentResource/YouTubeCreator/create-youtube-body.tsx
+++ b/packages/creators/src/ContentResource/YouTubeCreator/create-youtube-body.tsx
@@ -30,6 +30,7 @@ export function createYoutubeBodyResource(data: CreateYouTubeBodyPayload, ctx: C
     type: "Video",
     service: [
       {
+        type: "Service",
         profile: "http://digirati.com/objectifier",
         params: {
           data: `https://www.youtube.com/embed/${id}`,
@@ -37,6 +38,7 @@ export function createYoutubeBodyResource(data: CreateYouTubeBodyPayload, ctx: C
       },
       {
         id: `https://www.youtube.com/watch?v=${id}`,
+        type: "Service",
         profile: "https://www.youtube.com",
       },
     ],

--- a/packages/editor-api/package.json
+++ b/packages/editor-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifest-editor/editor-api",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "bugs": "https://github.com/digirati-co-uk/iiif-manifest-editor/issues",
   "repository": {

--- a/packages/editors/package.json
+++ b/packages/editors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifest-editor/editors",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "bugs": "https://github.com/digirati-co-uk/iiif-manifest-editor/issues",
   "repository": {
@@ -92,8 +92,8 @@
     "zustand": "catalog:"
   },
   "devDependencies": {
-    "@tsdown/css": "catalog:",
     "@manifest-editor/ui": "workspace:*",
+    "@tsdown/css": "catalog:",
     "@types/dompurify": "3.0.5",
     "@types/draft-convert": "^2.1.4",
     "@types/draft-js": "^0.11.9",

--- a/packages/editors/src/components/AppDropdown/AppDropdown.tsx
+++ b/packages/editors/src/components/AppDropdown/AppDropdown.tsx
@@ -122,7 +122,10 @@ export function AppDropdown({ as, items, children, "aria-label": ariaLabel, styl
                         <button
                           type="button"
                           {...(itemProps as any)[key]}
-                          onClick={item.onClick}
+                          onClick={() => {
+                            setIsOpen(false);
+                            item.onClick?.();
+                          }}
                           className="border-none outline-none bg-transparent m-0 p-0 text-inherit cursor-pointer hover:text-inherit flex-1 text-left p-1.5 rounded-sm flex hover:bg-blue-50 focus:bg-blue-50 focus:outline-2 focus:outline-[#bfd1ed]"
                         >
                           {item.icon ? (

--- a/packages/editors/src/components/AppDropdown/AppDropdown.tsx
+++ b/packages/editors/src/components/AppDropdown/AppDropdown.tsx
@@ -94,7 +94,11 @@ export function AppDropdown({ as, items, children, "aria-label": ariaLabel, styl
       </Comp>
       {isOpen && (
         <FloatingPortal>
-          <FloatingOverlay lockScroll style={{ zIndex: 60 }}>
+          <FloatingOverlay
+            lockScroll
+            style={{ zIndex: 60 }}
+            onClick={(event) => event.target === event.currentTarget && setIsOpen(false)}
+          >
             <FloatingFocusManager context={context} initialFocus={refs.floating}>
               <ul
                 role="menu"

--- a/packages/editors/src/definitions/CombinedEditor/CombinedEditor.tsx
+++ b/packages/editors/src/definitions/CombinedEditor/CombinedEditor.tsx
@@ -43,7 +43,6 @@ export function CombinedEditor({ config }: { config: EditorConfig }) {
     ${hideIfEmpty(descriptive.summary)}
     ${hideIfEmpty(descriptive.rights)}
     ${hideIfEmpty(descriptive.navDate)}
-    ${hideIfEmpty(descriptive.requiredStatement)}
     ${hideIfEmpty(descriptive.provider)}
     ${hideIfEmpty(descriptive.thumbnail)}
     ${hideIfEmpty(descriptive.language)}

--- a/packages/iiif-preview-server/package.json
+++ b/packages/iiif-preview-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifest-editor/iiif-preview-server",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "bugs": "https://github.com/digirati-co-uk/iiif-manifest-editor/issues",
   "repository": {

--- a/packages/manifest-editor/package.json
+++ b/packages/manifest-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-editor",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "bugs": "https://github.com/digirati-co-uk/iiif-manifest-editor/issues",
   "repository": {
@@ -110,8 +110,8 @@
     "react-iiif-vault": "catalog:"
   },
   "devDependencies": {
-    "@tsdown/css": "catalog:",
     "@manifest-editor/ui": "workspace:*",
+    "@tsdown/css": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "postcss": "^8.4.38",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/projects/package.json
+++ b/packages/projects/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifest-editor/projects",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "bugs": "https://github.com/digirati-co-uk/iiif-manifest-editor/issues",
   "repository": {

--- a/packages/server-vault/package.json
+++ b/packages/server-vault/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifest-editor/server-vault",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "bugs": "https://github.com/digirati-co-uk/iiif-manifest-editor/issues",
   "repository": {

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifest-editor/shell",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "bugs": "https://github.com/digirati-co-uk/iiif-manifest-editor/issues",
   "repository": {
@@ -70,8 +70,8 @@
     "zustand": "catalog:"
   },
   "devDependencies": {
-    "@tsdown/css": "catalog:",
     "@manifest-editor/ui": "workspace:*",
+    "@tsdown/css": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@types/react-transition-group": "^4.4.4",

--- a/packages/shell/src/EditingStack/EditingStack.tsx
+++ b/packages/shell/src/EditingStack/EditingStack.tsx
@@ -6,6 +6,7 @@ import { flushSync } from "react-dom";
 import { useResourceContext, useVault } from "react-iiif-vault";
 import invariant from "tiny-invariant";
 import { useAppInstance } from "../AppContext/AppContext";
+import { useEditingContext } from "../ResourceEditingContext/ResourceEditingContext";
 import { editingStackReducer } from "./EditingStack.reducer";
 import type { EditableResource, EditingStackActions, EditingStackState } from "./EditingStack.types";
 
@@ -129,6 +130,7 @@ export function useAnnotationPageEditor() {
 
 export function useEditor() {
   const resource = useEditingResource();
+  const { resource: contextualResource } = useEditingContext();
   const vault = useVault();
   const [key, invalidate] = useReducer((i: number) => i + 1, 0);
 
@@ -136,10 +138,10 @@ export function useEditor() {
 
   const editor = useMemo(() => {
     return new EditorInstance({
-      reference: resource.resource.source || resource.resource,
+      reference: contextualResource || resource.resource.source || resource.resource,
       vault,
     });
-  }, [resource, vault]);
+  }, [contextualResource, resource, vault]);
 
   useEffect(() => {
     return editor.observe.start(invalidate);

--- a/packages/shell/src/PresetOnboarding/PresetOnboarding.tsx
+++ b/packages/shell/src/PresetOnboarding/PresetOnboarding.tsx
@@ -1,10 +1,14 @@
 import { ActionButton, Modal } from "@manifest-editor/components";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useManifest } from "react-iiif-vault";
+import { useManifest, useVault } from "react-iiif-vault";
 import { useApp, useAppState, usePresetTemplateSelection } from "../AppContext/AppContext";
 import { useAppResource } from "../AppResourceProvider/AppResourceProvider";
 import { PreviewButton } from "../PreviewButton/PreviewButton";
-import { resolvePresetTemplateSelection } from "./preset-template-selection";
+import {
+  applyPresetTemplateSelection,
+  getConfiguredPresetTemplate,
+  resolvePresetTemplateSelection,
+} from "./preset-template-selection";
 
 const reopenEvent = "manifest-editor:preset-onboarding:open";
 
@@ -84,10 +88,13 @@ export function PresetOnboarding() {
   const { setState } = useAppState<{ presetOnboardingPreviewHintKey?: string | null }>();
   const templateSelection = usePresetTemplateSelection();
   const manifest = useManifest();
+  const vault = useVault();
+  const manifestBehavior = (manifest?.behavior as string[]) || [];
+  const configuredTemplate = getConfiguredPresetTemplate(templateSelection.templates, manifestBehavior);
   const resolvedTemplate = resolvePresetTemplateSelection(
     templateSelection.templates,
     templateSelection.selectedTemplateId,
-    (manifest?.behavior as string[]) || [],
+    manifestBehavior,
   );
   const selectedTemplateIdRef = useRef<string | null>(resolvedTemplate?.id || null);
   selectedTemplateIdRef.current = resolvedTemplate?.id || null;
@@ -100,10 +107,10 @@ export function PresetOnboarding() {
 
   useEffect(() => {
     if (!dismissalKey) return;
-    const shouldOpen = !isDismissed(dismissalKey);
+    const shouldOpen = !configuredTemplate && !isDismissed(dismissalKey);
     setOpen(shouldOpen);
     setAutoOpened(shouldOpen);
-  }, [dismissalKey]);
+  }, [configuredTemplate, dismissalKey]);
 
   useEffect(() => {
     const reopen = (event: Event) => {
@@ -134,6 +141,23 @@ export function PresetOnboarding() {
   const setSelectedTemplateId = (id: string | null) => {
     selectedTemplateIdRef.current = id;
     templateSelection.setSelectedTemplateId(id);
+    const selectedTemplate = templateSelection.templates.find((template) => template.id === id);
+    if (!manifest || !selectedTemplate) return;
+
+    const currentBehavior = (manifest.behavior as string[]) || [];
+    const behavior = applyPresetTemplateSelection(currentBehavior, selectedTemplate);
+    if (
+      behavior.length === currentBehavior.length &&
+      behavior.every((item, index) => item === currentBehavior[index])
+    ) {
+      return;
+    }
+    vault.modifyEntityField(manifest, "behavior", behavior);
+  };
+
+  const confirm = () => {
+    setSelectedTemplateId(selectedTemplateIdRef.current);
+    dismiss();
   };
 
   return (
@@ -145,7 +169,7 @@ export function PresetOnboarding() {
         <div className="flex gap-2">
           <ActionButton onPress={dismiss}>{onboarding.dismissLabel || "Dismiss"}</ActionButton>
           {resolvedTemplate ? (
-            <ActionButton primary onPress={dismiss}>
+            <ActionButton primary onPress={confirm}>
               {onboarding.primaryLabel || "Continue"}
             </ActionButton>
           ) : null}

--- a/packages/shell/src/PresetOnboarding/preset-template-selection.test.ts
+++ b/packages/shell/src/PresetOnboarding/preset-template-selection.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "vitest";
 import type { PresetTemplateDefinition } from "../AppContext/AppContext";
-import { resolvePresetTemplateSelection } from "./preset-template-selection";
+import {
+  applyPresetTemplateSelection,
+  getConfiguredPresetTemplate,
+  resolvePresetTemplateSelection,
+} from "./preset-template-selection";
 
 const template = (id: string, type: PresetTemplateDefinition["type"]): PresetTemplateDefinition => ({
   id,
@@ -12,7 +16,7 @@ const template = (id: string, type: PresetTemplateDefinition["type"]): PresetTem
 });
 
 describe("resolvePresetTemplateSelection", () => {
-  const templates = [template("one", "fullpage"), template("two", "slideshow")];
+  const templates = [template("one", "fullpage"), template("two", "slideshow"), template("three", "scroll")];
 
   test("falls back to the first permitted template", () => {
     expect(resolvePresetTemplateSelection(templates, null)?.id).toBe("one");
@@ -24,11 +28,45 @@ describe("resolvePresetTemplateSelection", () => {
     expect(resolvePresetTemplateSelection(templates, null, ["slideshow"])?.id).toBe("two");
   });
 
+  test("only treats a valid manifest behavior as configured", () => {
+    expect(getConfiguredPresetTemplate(templates, ["template-two"])?.id).toBe("two");
+    expect(getConfiguredPresetTemplate(templates, ["scroll"])?.id).toBe("three");
+    expect(getConfiguredPresetTemplate(templates, [])).toBeNull();
+    expect(getConfiguredPresetTemplate(templates, ["template-missing"])).toBeNull();
+  });
+
   test("retains a permitted selected template when the manifest has no format", () => {
     expect(resolvePresetTemplateSelection(templates, "two")?.id).toBe("two");
   });
 
   test("returns an explicit empty selection when no templates are permitted", () => {
     expect(resolvePresetTemplateSelection([], "filtered-out", ["template-filtered-out"])).toBeNull();
+  });
+
+  test("keeps each loaded manifest authoritative until an explicit selection", () => {
+    const slideshow = ["template-two"];
+    const scrolling = ["scroll"];
+    const unconfigured: string[] = [];
+
+    expect(resolvePresetTemplateSelection(templates, "two", scrolling)?.id).toBe("three");
+    expect(scrolling).toEqual(["scroll"]);
+
+    const fullpage = applyPresetTemplateSelection(scrolling, templates[0]!);
+    expect(fullpage).toEqual(["fullpage", "template-one"]);
+    expect(resolvePresetTemplateSelection(templates, "one", fullpage)?.id).toBe("one");
+    expect(resolvePresetTemplateSelection(templates, "one", slideshow)?.id).toBe("two");
+
+    expect(resolvePresetTemplateSelection(templates, "two", unconfigured)?.id).toBe("two");
+    expect(unconfigured).toEqual([]);
+    expect(applyPresetTemplateSelection(unconfigured, templates[1]!)).toEqual(["slideshow", "template-two"]);
+  });
+
+  test("replaces conflicting format behaviours exactly once", () => {
+    expect(
+      applyPresetTemplateSelection(
+        ["paged", "scroll", "slideshow", "fullpage", "template-old", "template-old"],
+        templates[1]!,
+      ),
+    ).toEqual(["paged", "slideshow", "template-two"]);
   });
 });

--- a/packages/shell/src/PresetOnboarding/preset-template-selection.ts
+++ b/packages/shell/src/PresetOnboarding/preset-template-selection.ts
@@ -1,14 +1,31 @@
 import type { PresetTemplateDefinition } from "../AppContext/AppContext";
 
+const presetTemplateTypes = new Set<string>(["fullpage", "slideshow", "scroll"]);
+
+export function applyPresetTemplateSelection(behavior: string[], template: PresetTemplateDefinition) {
+  return [
+    ...behavior.filter((item) => !item.startsWith("template-") && !presetTemplateTypes.has(item)),
+    template.type,
+    `template-${template.id}`,
+  ];
+}
+
+export function getConfiguredPresetTemplate(templates: PresetTemplateDefinition[], behavior: string[] = []) {
+  const templateId = behavior.find((item) => item.startsWith("template-"))?.slice("template-".length);
+  return (
+    templates.find((template) => template.id === templateId) ||
+    templates.find((template) => behavior.includes(template.type)) ||
+    null
+  );
+}
+
 export function resolvePresetTemplateSelection(
   templates: PresetTemplateDefinition[],
   selectedTemplateId?: string | null,
   behavior: string[] = [],
 ) {
-  const templateId = behavior.find((item) => item.startsWith("template-"))?.slice("template-".length);
   return (
-    templates.find((template) => template.id === templateId) ||
-    templates.find((template) => behavior.includes(template.type)) ||
+    getConfiguredPresetTemplate(templates, behavior) ||
     templates.find((template) => template.id === selectedTemplateId) ||
     templates[0] ||
     null

--- a/packages/shell/src/PreviewWindow/PreviewWindowContext.tsx
+++ b/packages/shell/src/PreviewWindow/PreviewWindowContext.tsx
@@ -1,0 +1,143 @@
+import type { Vault } from "@iiif/helpers/vault";
+import { createContext, type ReactNode, useCallback, useContext, useEffect, useRef, useState } from "react";
+import { useVault } from "react-iiif-vault";
+import invariant from "tiny-invariant";
+import { createIframeVaultBridge } from "../PreviewVault/vault-message-bridge";
+
+const PREVIEW_CONNECT = "manifest-editor:iframe-preview:connect";
+const PREVIEW_READY = "manifest-editor:iframe-preview:ready";
+const PREVIEW_SELECTION = "manifest-editor:iframe-preview:selection";
+
+export type PreviewWindowOptions = {
+  url: string;
+  resource: { id: string; type: string };
+  canvasId?: string | null;
+  annotationId?: string | null;
+  name?: string;
+  features?: string;
+  reloadKey?: string;
+};
+
+type PreviewWindowContextValue = {
+  open: (options: PreviewWindowOptions) => void;
+  update: (options: PreviewWindowOptions) => void;
+  focus: () => void;
+  isClosed: boolean;
+};
+
+const PreviewWindowReactContext = createContext<PreviewWindowContextValue | null>(null);
+
+export function PreviewWindowProvider({ children }: { children: ReactNode }) {
+  const vault = useVault();
+  const previewWindow = useRef<Window | null>(null);
+  const options = useRef<PreviewWindowOptions | null>(null);
+  const cleanupBridge = useRef<(() => void) | null>(null);
+  const connected = useRef(false);
+  const [isClosed, setIsClosed] = useState(true);
+
+  const connect = useCallback(() => {
+    if (!previewWindow.current || previewWindow.current.closed || !options.current) return;
+
+    cleanupBridge.current?.();
+    const channel = new MessageChannel();
+    cleanupBridge.current = createIframeVaultBridge(vault as Vault, channel.port1);
+    previewWindow.current.postMessage(
+      {
+        _type: PREVIEW_CONNECT,
+        resource: options.current.resource,
+        canvasId: options.current.canvasId || null,
+        annotationId: options.current.annotationId || undefined,
+      },
+      new URL(options.current.url).origin,
+      [channel.port2]
+    );
+    connected.current = true;
+  }, [vault]);
+
+  useEffect(() => {
+    const handleReady = (event: MessageEvent) => {
+      if (!options.current || event.source !== previewWindow.current) return;
+      if (event.origin !== new URL(options.current.url).origin) return;
+      if (event.data?._type === PREVIEW_READY) connect();
+    };
+    const checkClosed = window.setInterval(() => {
+      if (previewWindow.current?.closed) {
+        cleanupBridge.current?.();
+        cleanupBridge.current = null;
+        connected.current = false;
+        previewWindow.current = null;
+        setIsClosed(true);
+      }
+    }, 1000);
+
+    window.addEventListener("message", handleReady);
+    return () => {
+      window.removeEventListener("message", handleReady);
+      window.clearInterval(checkClosed);
+      cleanupBridge.current?.();
+    };
+  }, [connect]);
+
+  const open = useCallback((nextOptions: PreviewWindowOptions) => {
+    options.current = nextOptions;
+    const current = previewWindow.current;
+
+    if (current && !current.closed) {
+      current.focus();
+      return;
+    }
+
+    cleanupBridge.current?.();
+    cleanupBridge.current = null;
+    connected.current = false;
+    previewWindow.current = window.open(
+      nextOptions.url,
+      nextOptions.name || "manifest-editor-preview",
+      nextOptions.features || "popup,width=1200,height=900"
+    );
+    setIsClosed(!previewWindow.current);
+  }, []);
+
+  const update = useCallback((nextOptions: PreviewWindowOptions) => {
+    const previous = options.current;
+    options.current = nextOptions;
+    const current = previewWindow.current;
+    if (!current || current.closed) return;
+
+    if (previous && (previous.url !== nextOptions.url || previous.reloadKey !== nextOptions.reloadKey)) {
+      cleanupBridge.current?.();
+      cleanupBridge.current = null;
+      connected.current = false;
+      current.location.href = nextOptions.url;
+      return;
+    }
+
+    if (connected.current) {
+      current.postMessage(
+        {
+          _type: PREVIEW_SELECTION,
+          resource: nextOptions.resource,
+          canvasId: nextOptions.canvasId || null,
+          annotationId: nextOptions.annotationId || undefined,
+        },
+        new URL(nextOptions.url).origin
+      );
+    }
+  }, []);
+
+  const focus = useCallback(() => {
+    if (previewWindow.current && !previewWindow.current.closed) previewWindow.current.focus();
+  }, []);
+
+  return (
+    <PreviewWindowReactContext.Provider value={{ open, update, focus, isClosed }}>
+      {children}
+    </PreviewWindowReactContext.Provider>
+  );
+}
+
+export function usePreviewWindow() {
+  const context = useContext(PreviewWindowReactContext);
+  invariant(context, "usePreviewWindow() can only be called from inside <PreviewWindowProvider />");
+  return context;
+}

--- a/packages/shell/src/ShellContext/ShellContext.tsx
+++ b/packages/shell/src/ShellContext/ShellContext.tsx
@@ -15,6 +15,7 @@ import { PluginConfigBridge } from "../PluginContext/PluginContext";
 import { PreviewProvider } from "../PreviewContext/PreviewContext";
 import type { Preview, PreviewConfiguration } from "../PreviewContext/PreviewContext.types";
 import { PreviewVaultContext } from "../PreviewVault/PreviewVault";
+import { PreviewWindowProvider } from "../PreviewWindow/PreviewWindowContext";
 import { ToastProvider } from "../Toast/ToastContext";
 import { defaultTheme } from "./default-theme";
 
@@ -86,7 +87,7 @@ export function ShellProvider({
       {
         previews: resolvedPreviews,
       },
-      config,
+      config
     );
   }, [existingConfig, config]);
   const backgroundActionPersistenceKey = useMemo(
@@ -98,7 +99,7 @@ export function ShellProvider({
         type: resource.type,
       },
     }),
-    [app.appId, app.instanceId, resource.id, resource.type],
+    [app.appId, app.instanceId, resource.id, resource.type]
   );
 
   return (
@@ -119,7 +120,9 @@ export function ShellProvider({
                         <ToastProvider>
                           {/* @todo swap these out for (config?.previews || []) */}
                           <PreviewProvider previews={previews || []} configs={mergedConfig.previews}>
-                            <AtlasStoreProvider>{children}</AtlasStoreProvider>
+                            <PreviewWindowProvider>
+                              <AtlasStoreProvider>{children}</AtlasStoreProvider>
+                            </PreviewWindowProvider>
                           </PreviewProvider>
                         </ToastProvider>
                       </ContextMenuProvider>

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -57,6 +57,7 @@ export * from "./PreviewContext/PreviewContext.types";
 export * from "./PreviewVault/create-preview-vault";
 export * from "./PreviewVault/vault-message-bridge";
 export * from "./PreviewVault/PreviewVault";
+export * from "./PreviewWindow/PreviewWindowContext";
 export * from "./ResourceEditingContext/ResourceEditingContext";
 export * from "./ResourceEditingContext/ResourceEditingContext.types";
 export * from "./ShellContext/ShellContext";

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifest-editor/ui",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "bugs": "https://github.com/digirati-co-uk/iiif-manifest-editor/issues",
   "repository": {

--- a/plugins/annotations/package.json
+++ b/plugins/annotations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifest-editor/annotations",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "bugs": "https://github.com/digirati-co-uk/iiif-manifest-editor/issues",
   "repository": {

--- a/plugins/canvas-label-generator/package.json
+++ b/plugins/canvas-label-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifest-editor/canvas-label-generator",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "bugs": "https://github.com/digirati-co-uk/iiif-manifest-editor/issues",
   "repository": {

--- a/plugins/ocr-classification/package.json
+++ b/plugins/ocr-classification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifest-editor/ocr-classification",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "bugs": "https://github.com/digirati-co-uk/iiif-manifest-editor/issues",
   "repository": {

--- a/plugins/ocr-docling/package.json
+++ b/plugins/ocr-docling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifest-editor/ocr-docling",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "bugs": "https://github.com/digirati-co-uk/iiif-manifest-editor/issues",
   "repository": {

--- a/plugins/specifications/package.json
+++ b/plugins/specifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifest-editor/specifications",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "bugs": "https://github.com/digirati-co-uk/iiif-manifest-editor/issues",
   "repository": {

--- a/plugins/translation/package.json
+++ b/plugins/translation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifest-editor/translation",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "bugs": "https://github.com/digirati-co-uk/iiif-manifest-editor/issues",
   "repository": {

--- a/presets/collection-preset/package.json
+++ b/presets/collection-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifest-editor/collection-preset",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "bugs": "https://github.com/digirati-co-uk/iiif-manifest-editor/issues",
   "repository": {

--- a/presets/exhibition-preset/package.json
+++ b/presets/exhibition-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifest-editor/exhibition-preset",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "bugs": "https://github.com/digirati-co-uk/iiif-manifest-editor/issues",
   "repository": {
@@ -65,8 +65,8 @@
     "zustand": "catalog:"
   },
   "devDependencies": {
-    "@tsdown/css": "catalog:",
     "@manifest-editor/ui": "workspace:*",
+    "@tsdown/css": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "tiny-invariant": "^1.3.3",

--- a/presets/exhibition-preset/src/canvas-editors/info-block-editor.tsx
+++ b/presets/exhibition-preset/src/canvas-editors/info-block-editor.tsx
@@ -1,4 +1,5 @@
 import { ActionButton, HTMLEditor } from "@manifest-editor/components";
+import { addMappings, importEntities } from "@iiif/helpers/vault/actions";
 import {
   type CanvasEditorDefinition,
   useConfig,
@@ -132,7 +133,7 @@ function LanguageSelector({
                     ) : (
                       <div className="h-3 w-3 shrink-0 text-slate-500" />
                     )}
-                    <span className={lang === selectedLanguage ? "" : "ml-5"}>{details?.label || lang}</span>
+                    <span>{details?.label || lang}</span>
                   </button>
                 );
               })}
@@ -204,7 +205,6 @@ function collectLanguagesFromPage(page: any, vault: any): string[] {
 
 function InfoBlockEditor({ strategy }: { strategy: TextualContentStrategy }) {
   const canvas = useCanvas();
-  const vault = useVault();
   const behavior = canvas?.behavior || [];
   const dims = getHeightWidthRatio(behavior);
   const hasDimension = Boolean(dims.h && dims.w);
@@ -227,23 +227,23 @@ function InfoBlockEditor({ strategy }: { strategy: TextualContentStrategy }) {
   const longSummaryHeading = isFullPagePreset ? "Read more text in modal" : "Summary";
 
   // Collect all languages present in the canvas
-  const presentLanguages = useMemo(() => {
-    const fromItems = collectLanguagesFromPage(annotationPage, vault);
-    const fromAnnotations = collectLanguagesFromPage(longSummaries, vault);
-    const all = new Set([...fromItems, ...fromAnnotations]);
-    if (all.size === 0) all.add(defaultLanguage || "en");
-    return Array.from(all);
-  }, [annotationPage, longSummaries, vault, defaultLanguage]);
-
-  const [selectedLanguage, setSelectedLanguage] = useLocalStorage<string>(
-    "exhibition-info-block-language",
-    defaultLanguage || "en",
+  const presentLanguages = useVaultSelector(
+    (_, selectedVault) => {
+      const fromItems = collectLanguagesFromPage(annotationPage, selectedVault);
+      const fromAnnotations = collectLanguagesFromPage(longSummaries, selectedVault);
+      const all = new Set([...fromItems, ...fromAnnotations]);
+      if (all.size === 0) all.add(defaultLanguage || "en");
+      return Array.from(all);
+    },
+    [annotationPage?.id, longSummaries?.id, defaultLanguage],
   );
 
-  // Make sure selected language is always in the present list
-  const effectiveLanguage = presentLanguages.includes(selectedLanguage)
-    ? selectedLanguage
-    : presentLanguages[0] || defaultLanguage || "en";
+  const [selectedLanguage, setSelectedLanguage] = useState<string>();
+  const effectiveLanguage =
+    selectedLanguage ||
+    (presentLanguages.includes(defaultLanguage)
+      ? defaultLanguage
+      : presentLanguages[0] || defaultLanguage || "en");
 
   // When a new language is added we switch to it immediately
   const handleAddLanguage = (lang: string) => {
@@ -256,7 +256,7 @@ function InfoBlockEditor({ strategy }: { strategy: TextualContentStrategy }) {
   return (
     <div className="relative z-0 flex h-full min-h-0 w-full min-w-0 max-w-full flex-col overflow-hidden bg-white">
       {/* Toolbar — same height and position as the image viewer toolbar */}
-      <div className="exhibition-slideshow-current-toolbar flex items-center gap-3 border-b border-slate-200 bg-white px-4 py-3 shadow-sm">
+      <div className="exhibition-slideshow-current-toolbar relative z-[70] flex items-center gap-3 border-b border-slate-200 bg-white px-4 py-3 shadow-sm">
         <div className="min-w-0 flex-1">
           <LocaleString className="block truncate text-sm font-semibold text-slate-800">{canvas?.label}</LocaleString>
         </div>
@@ -438,17 +438,22 @@ function SummarySection({
       const firstBody = firstBodyRef ? resolveResource(firstBodyRef, vault) : null;
       const newBodyId = `${annotation.id}-body-${selectedLanguage}-${Date.now()}`;
       vault.batch(() => {
-        vault.dispatch({
-          type: "entities/update",
-          payload: {
-            type: "ContentResource",
-            id: newBodyId,
-            language: selectedLanguage,
-            value: "",
-            format: firstBody?.format || "text/html",
-            motivation: firstBody?.motivation,
-          },
-        });
+        vault.dispatch(
+          importEntities({
+            entities: {
+              ContentResource: {
+                [newBodyId]: {
+                  id: newBodyId,
+                  type: firstBody?.type || "TextualBody",
+                  language: selectedLanguage,
+                  value: "",
+                  format: firstBody?.format || "text/html",
+                },
+              },
+            },
+          }),
+        );
+        vault.dispatch(addMappings({ mapping: { [newBodyId]: "ContentResource" } }));
         vault.modifyEntityField({ id: annotation.id, type: "Annotation" }, "body", [
           ...bodies,
           { id: newBodyId, type: "ContentResource" },
@@ -467,19 +472,22 @@ function SummarySection({
   };
 
   // Check whether the selected language is already represented in this page
-  const languageExistsInPage = useMemo(() => {
-    if (!page) return false;
-    for (const annotationRef of items) {
-      const annotation = resolveResource(annotationRef, vault);
-      if (!annotation) continue;
-      const bodies = toArray(annotation.body);
-      for (const bodyRef of bodies) {
-        const body = resolveResource(bodyRef, vault);
-        if (body?.language === selectedLanguage) return true;
+  const languageExistsInPage = useVaultSelector(
+    (_, selectedVault) => {
+      if (!page) return false;
+      for (const annotationRef of items) {
+        const annotation = resolveResource(annotationRef, selectedVault);
+        if (!annotation) continue;
+        const bodies = toArray(annotation.body);
+        for (const bodyRef of bodies) {
+          const body = resolveResource(bodyRef, selectedVault);
+          if (body?.language === selectedLanguage) return true;
+        }
       }
-    }
-    return false;
-  }, [page, items, vault, selectedLanguage]);
+      return false;
+    },
+    [page?.id, items, selectedLanguage],
+  );
 
   return (
     <section className={twMerge("min-w-0 max-w-full", panelClassName)}>

--- a/presets/exhibition-preset/src/components/ExhibitionItem.tsx
+++ b/presets/exhibition-preset/src/components/ExhibitionItem.tsx
@@ -1,14 +1,10 @@
-import { LazyThumbnail } from "@manifest-editor/components";
+import { LazyThumbnail, useCanvasRenderingStrategy } from "@manifest-editor/components";
 import {
   getInternationalStringText,
   useInStack,
 } from "@manifest-editor/editors";
 import { forwardRef } from "react";
-import {
-  LocaleString,
-  useCanvas,
-  useRenderingStrategy,
-} from "react-iiif-vault";
+import { LocaleString, useCanvas } from "react-iiif-vault";
 import { twMerge } from "tailwind-merge";
 import { getClassName, getGridStats } from "../helpers";
 import { SlideshowSlidePreview } from "./SlideshowSlidePreview";
@@ -26,7 +22,7 @@ export const ExhibitionItem = forwardRef<HTMLDivElement, ExhibitionItemProps>(
     ref,
   ) {
     const canvas = useCanvas();
-    const [strategy] = useRenderingStrategy();
+    const strategy = useCanvasRenderingStrategy();
     const behavior = canvas?.behavior || [];
     const currentCanvas = useInStack("Canvas");
     const className = getClassName(canvas?.behavior, isFirst);

--- a/presets/exhibition-preset/src/components/ExhibitionItemConversion.tsx
+++ b/presets/exhibition-preset/src/components/ExhibitionItemConversion.tsx
@@ -5,7 +5,11 @@ import {
   withExhibitionDefaults,
 } from "./exhibition-item-defaults";
 
-export function ExhibitionItemConversion() {
+export function ExhibitionItemConversion({
+  misplacedSplash = false,
+}: {
+  misplacedSplash?: boolean;
+}) {
   const editor = useEditor();
 
   const applyDefaultSettings = () => {
@@ -16,7 +20,9 @@ export function ExhibitionItemConversion() {
 
     const currentBehaviors = behaviors.get();
     const defaultBehaviors = withExhibitionDefaults(
-      currentBehaviors,
+      misplacedSplash
+        ? currentBehaviors.filter((behavior) => behavior !== "splash")
+        : currentBehaviors,
       canvasWidth,
       canvasHeight,
     );
@@ -37,8 +43,9 @@ export function ExhibitionItemConversion() {
 
   return (
     <div className="flex flex-col items-center gap-4 border-me-100 border-2 p-4 rounded">
-      This canvas was not created in the exhibition editor. Do you want to apply
-      default settings?
+      {misplacedSplash
+        ? "Opening cover canvases must be first. Apply defaults to use this canvas as a regular exhibition slide."
+        : "This canvas was not created in the exhibition editor. Do you want to apply default settings?"}
       <ActionButton onPress={() => applyDefaultSettings()}>
         Apply defaults
       </ActionButton>

--- a/presets/exhibition-preset/src/components/ExhibitionPreviewPanel.tsx
+++ b/presets/exhibition-preset/src/components/ExhibitionPreviewPanel.tsx
@@ -1,8 +1,5 @@
 import { useInStack } from "@manifest-editor/editors";
-import {
-  createIframeVaultBridge,
-  useAppResource,
-} from "@manifest-editor/shell";
+import { createIframeVaultBridge, useAppResource, usePreviewWindow } from "@manifest-editor/shell";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useManifest, useVault, useVaultSelector } from "react-iiif-vault";
 import { twMerge } from "tailwind-merge";
@@ -13,10 +10,7 @@ import {
 } from "../helpers/exhibition-preview-url-helper";
 import { useExhibitionTemplate } from "../helpers/exhibition-template";
 import { useSlideshowContentPositioning } from "../slideshow-content-positioning";
-import {
-  getPreviewImageTransformKey,
-  getPreviewStructureKey,
-} from "./preview-structure";
+import { getPreviewImageTransformKey, getPreviewStructureKey } from "./preview-structure";
 
 export interface ExhibitionPreviewPanelProps {
   preset: PresetUrlSearchParamsPreset;
@@ -36,6 +30,7 @@ export function ExhibitionPreviewPanel({
   presetOptions,
   focusSelectedCanvas = true,
 }: ExhibitionPreviewPanelProps) {
+  const previewWindow = useExhibitionPreviewWindow({ preset, presetOptions, focusSelectedCanvas });
   const vault = useVault();
   const rootResource = useAppResource();
   const manifest = useManifest();
@@ -47,33 +42,21 @@ export function ExhibitionPreviewPanel({
   const resourceRef = useRef(rootResource);
   const canvasIdRef = useRef<string | null>(null);
   const annotationIdRef = useRef<string | null>(null);
-  const [status, setStatus] = useState<"waiting" | "connected" | "error">(
-    "waiting",
-  );
+  const [status, setStatus] = useState<"waiting" | "connected" | "error">("waiting");
   const [viewportWidth, setViewportWidth] = useState(0);
   const [useScaledPreview, setUseScaledPreview] = useState(false);
   const [useMobileWidthPreview, setUseMobileWidthPreview] = useState(false);
-  const selectedTourStepId = useSlideshowContentPositioning(
-    (state) => state.selectedTourStepId,
-  );
-  const currentCanvasId = focusSelectedCanvas
-    ? canvas?.resource.source.id || manifest?.items?.[0]?.id || null
-    : null;
+  const selectedTourStepId = useSlideshowContentPositioning((state) => state.selectedTourStepId);
+  const currentCanvasId = focusSelectedCanvas ? canvas?.resource.source.id || manifest?.items?.[0]?.id || null : null;
   const structureKey = getPreviewStructureKey(rootResource, manifest?.items);
   const imageTransformKey = useVaultSelector(
-    (_, currentVault) =>
-      getPreviewImageTransformKey(currentVault, manifest?.items),
-    [structureKey],
+    (_, currentVault) => getPreviewImageTransformKey(currentVault, manifest?.items),
+    [structureKey]
   );
   const previousStructureKeyRef = useRef(structureKey);
   const src = useMemo(
-    () =>
-      createScrollingPreviewUrl(
-        preset,
-        presetOptions,
-        template?.previewUrl,
-      ).toString(),
-    [preset, presetOptions, template?.previewUrl],
+    () => createScrollingPreviewUrl(preset, presetOptions, template?.previewUrl).toString(),
+    [preset, presetOptions, template?.previewUrl]
   );
   const targetOrigin = useMemo(() => new URL(src).origin, [src]);
   const previewScale = useScaledPreview ? SCALED_PREVIEW_SIZE : 1;
@@ -82,8 +65,7 @@ export function ExhibitionPreviewPanel({
     : viewportWidth
       ? Math.round(viewportWidth / previewScale)
       : 0;
-  const isMobileViewport =
-    iframeViewportWidth > 0 && iframeViewportWidth <= MOBILE_VIEWPORT_WIDTH;
+  const isMobileViewport = iframeViewportWidth > 0 && iframeViewportWidth <= MOBILE_VIEWPORT_WIDTH;
 
   resourceRef.current = rootResource;
   canvasIdRef.current = currentCanvasId;
@@ -108,7 +90,7 @@ export function ExhibitionPreviewPanel({
           annotationId: annotationIdRef.current || undefined,
         },
         targetOrigin,
-        [channel.port2],
+        [channel.port2]
       );
       setStatus("connected");
     } catch {
@@ -144,16 +126,9 @@ export function ExhibitionPreviewPanel({
         canvasId: currentCanvasId,
         annotationId: selectedTourStepId || undefined,
       },
-      targetOrigin,
+      targetOrigin
     );
-  }, [
-    status,
-    rootResource.id,
-    rootResource.type,
-    currentCanvasId,
-    selectedTourStepId,
-    targetOrigin,
-  ]);
+  }, [status, rootResource, currentCanvasId, selectedTourStepId, targetOrigin]);
 
   useEffect(() => {
     const structureChanged = previousStructureKeyRef.current !== structureKey;
@@ -208,28 +183,25 @@ export function ExhibitionPreviewPanel({
     <div className="flex h-full min-h-0 flex-col bg-zinc-950">
       {status !== "connected" ? (
         <div className="border-b border-zinc-800 bg-zinc-900 px-3 py-2 text-sm text-zinc-300">
-          {status === "error"
-            ? "Preview connection failed."
-            : "Connecting to exhibition viewer..."}
+          {status === "error" ? "Preview connection failed." : "Connecting to exhibition viewer..."}
         </div>
       ) : null}
       <PreviewViewportNotice
         iframeViewportWidth={iframeViewportWidth}
         isMobileViewport={isMobileViewport}
-        showScaleOption={
-          viewportWidth > 0 && viewportWidth <= MOBILE_VIEWPORT_WIDTH
-        }
+        showScaleOption={viewportWidth > 0 && viewportWidth <= MOBILE_VIEWPORT_WIDTH}
         showMobileWidthOption={viewportWidth > MOBILE_VIEWPORT_WIDTH}
         useScaledPreview={useScaledPreview}
         useMobileWidthPreview={useMobileWidthPreview}
         onUseScaledPreviewChange={setScaledPreview}
         onUseMobileWidthPreviewChange={setMobileWidthPreview}
+        previewWindow={previewWindow}
       />
       <div
         ref={viewportRef}
         className={twMerge(
           "flex min-h-0 flex-1 overflow-hidden bg-white",
-          useScaledPreview ? "justify-start" : "justify-center",
+          useScaledPreview ? "justify-start" : "justify-center"
         )}
       >
         <iframe
@@ -239,7 +211,7 @@ export function ExhibitionPreviewPanel({
           title="Exhibition preview"
           className={twMerge(
             "block h-full shrink-0 border-0 bg-white",
-            useMobileWidthPreview ? "shadow-2xl shadow-black/40" : "",
+            useMobileWidthPreview ? "shadow-2xl shadow-black/40" : ""
           )}
           style={{
             width: useMobileWidthPreview
@@ -249,15 +221,58 @@ export function ExhibitionPreviewPanel({
                 : "100%",
             maxWidth: useMobileWidthPreview ? "100%" : undefined,
             height: useScaledPreview ? `${100 / SCALED_PREVIEW_SIZE}%` : "100%",
-            transform: useScaledPreview
-              ? `scale(${SCALED_PREVIEW_SIZE})`
-              : undefined,
+            transform: useScaledPreview ? `scale(${SCALED_PREVIEW_SIZE})` : undefined,
             transformOrigin: "top left",
           }}
           onLoad={() => setStatus("waiting")}
         />
       </div>
     </div>
+  );
+}
+
+export function useExhibitionPreviewWindow({
+  preset,
+  presetOptions,
+  focusSelectedCanvas = true,
+}: ExhibitionPreviewPanelProps) {
+  const { open, update, focus, isClosed } = usePreviewWindow();
+  const rootResource = useAppResource();
+  const manifest = useManifest();
+  const template = useExhibitionTemplate();
+  const canvas = useInStack("Canvas");
+  const selectedTourStepId = useSlideshowContentPositioning((state) => state.selectedTourStepId);
+  const currentCanvasId = focusSelectedCanvas ? canvas?.resource.source.id || manifest?.items?.[0]?.id || null : null;
+  const structureKey = getPreviewStructureKey(rootResource, manifest?.items);
+  const imageTransformKey = useVaultSelector(
+    (_, currentVault) => getPreviewImageTransformKey(currentVault, manifest?.items),
+    [structureKey]
+  );
+  const url = useMemo(
+    () => createScrollingPreviewUrl(preset, presetOptions, template?.previewUrl).toString(),
+    [preset, presetOptions, template?.previewUrl]
+  );
+  const options = useMemo(
+    () => ({
+      url,
+      resource: rootResource,
+      canvasId: currentCanvasId,
+      annotationId: selectedTourStepId,
+      name: "manifest-editor-exhibition-preview",
+      reloadKey: `${structureKey}:${imageTransformKey}`,
+    }),
+    [currentCanvasId, imageTransformKey, rootResource, selectedTourStepId, structureKey, url]
+  );
+
+  useEffect(() => update(options), [options, update]);
+
+  return useMemo(
+    () => ({
+      open: () => open(options),
+      focus,
+      isClosed,
+    }),
+    [focus, isClosed, open, options]
   );
 }
 
@@ -270,6 +285,7 @@ function PreviewViewportNotice({
   useMobileWidthPreview,
   onUseScaledPreviewChange,
   onUseMobileWidthPreviewChange,
+  previewWindow,
 }: {
   iframeViewportWidth: number;
   isMobileViewport: boolean;
@@ -279,6 +295,7 @@ function PreviewViewportNotice({
   useMobileWidthPreview: boolean;
   onUseScaledPreviewChange: (useScaledPreview: boolean) => void;
   onUseMobileWidthPreviewChange: (useMobileWidthPreview: boolean) => void;
+  previewWindow: Pick<ReturnType<typeof useExhibitionPreviewWindow>, "open" | "focus" | "isClosed">;
 }) {
   if (!iframeViewportWidth) {
     return null;
@@ -292,32 +309,37 @@ function PreviewViewportNotice({
             "shrink-0 rounded-full px-2 py-1 font-semibold ring-1 ring-inset",
             isMobileViewport
               ? "bg-amber-300/90 text-amber-950 ring-amber-200/50"
-              : "bg-emerald-300/90 text-emerald-950 ring-emerald-200/50",
+              : "bg-emerald-300/90 text-emerald-950 ring-emerald-200/50"
           )}
         >
           {isMobileViewport ? "Mobile view" : "Desktop view"}
         </span>
         <span className="truncate text-zinc-400">
-          Iframe viewport: {iframeViewportWidth}px. Mobile starts at{" "}
-          {MOBILE_VIEWPORT_WIDTH}px and below.
+          Iframe viewport: {iframeViewportWidth}px. Mobile starts at {MOBILE_VIEWPORT_WIDTH}px and below.
         </span>
       </div>
 
-      {showScaleOption ? (
-        <PreviewToggle
-          label="50% scale"
-          checked={useScaledPreview}
-          onChange={onUseScaledPreviewChange}
-        />
-      ) : null}
+      <div className="flex items-center gap-2">
+        {showScaleOption ? (
+          <PreviewToggle label="50% scale" checked={useScaledPreview} onChange={onUseScaledPreviewChange} />
+        ) : null}
 
-      {showMobileWidthOption ? (
-        <PreviewToggle
-          label="Mobile width"
-          checked={useMobileWidthPreview}
-          onChange={onUseMobileWidthPreviewChange}
-        />
-      ) : null}
+        {showMobileWidthOption ? (
+          <PreviewToggle
+            label="Mobile width"
+            checked={useMobileWidthPreview}
+            onChange={onUseMobileWidthPreviewChange}
+          />
+        ) : null}
+
+        <button
+          type="button"
+          className="shrink-0 rounded-md border border-zinc-700 bg-zinc-950/70 px-2.5 py-1.5 font-semibold text-zinc-200 shadow-sm shadow-black/20 transition-colors hover:border-zinc-600 hover:bg-zinc-950"
+          onClick={previewWindow.isClosed ? previewWindow.open : previewWindow.focus}
+        >
+          {previewWindow.isClosed ? "Open in new window" : "Focus preview window"}
+        </button>
+      </div>
     </div>
   );
 }

--- a/presets/exhibition-preset/src/components/lazy-thumbnail-region.test.ts
+++ b/presets/exhibition-preset/src/components/lazy-thumbnail-region.test.ts
@@ -5,8 +5,16 @@ import {
   getRegionIntersection,
   imageUrlWithRegion,
   imageUrlWithTransform,
+  paintingAnnotationTargetsCanvas,
   shouldUseComplexCanvasThumbnail,
 } from "../../../../packages/components/src/LazyThumbnail";
+
+describe("paintingAnnotationTargetsCanvas", () => {
+  test("ignores painting annotations belonging to another canvas", () => {
+    expect(paintingAnnotationTargetsCanvas({ target: "canvas-2#xywh=0,0,100,100" }, "canvas-1")).toBe(false);
+    expect(paintingAnnotationTargetsCanvas({ target: "canvas-1#xywh=0,0,100,100" }, "canvas-1")).toBe(true);
+  });
+});
 
 describe("getRegionIntersection", () => {
   test("returns the overlapping canvas region", () => {

--- a/presets/exhibition-preset/src/creators/image-browser-slide-creator.test.ts
+++ b/presets/exhibition-preset/src/creators/image-browser-slide-creator.test.ts
@@ -50,7 +50,7 @@ describe("imageBrowserSlideCreator", () => {
     ];
     const ctx: any = {
       config: {},
-      options: { targetType: "Canvas" },
+      options: { targetType: "Canvas", initialData: { imageSlideBehavior: ["splash"] } },
       embed: vi.fn((resource) => ({
         get: () => resource,
         ref: () => ({ id: resource.id, type: resource.type }),
@@ -78,6 +78,7 @@ describe("imageBrowserSlideCreator", () => {
       rights: manifestTracking.rights,
       metadata: manifestTracking.metadata,
       partOf: manifestTracking.partOf,
+      behavior: ["splash"],
       width: 640,
       height: 480,
     });

--- a/presets/exhibition-preset/src/exhibition-onboarding.tsx
+++ b/presets/exhibition-preset/src/exhibition-onboarding.tsx
@@ -17,18 +17,14 @@ import {
   usePreviewContext,
 } from "@manifest-editor/shell";
 import { DownIcon } from "@manifest-editor/ui/icons/DownIcon";
-import { type SVGProps, useEffect } from "react";
+import { type SVGProps } from "react";
 import { Button, Menu, MenuItem, MenuTrigger, Popover } from "react-aria-components";
-import { useManifest, useVault } from "react-iiif-vault";
+import { useVault } from "react-iiif-vault";
 import { getExhibitionTemplatePreviews, useExhibitionTemplate } from "./helpers/exhibition-template";
 import { exhibitionTemplates } from "./exhibition-templates";
 
 export { exhibitionTemplates } from "./exhibition-templates";
 
-const exhibitionTemplateBehaviors = exhibitionTemplates.flatMap((template) => [
-  template.type,
-  `template-${template.id}`,
-]);
 const exhibitionTemplateShortLabels = {
   fullpage: "Full page",
   slideshow: "Slideshow",
@@ -111,7 +107,6 @@ function ExhibitionPresetPreviewButton({
 }: PresetPreviewButtonRenderContext) {
   const { actions, configs, active } = usePreviewContext();
   const vault = useVault();
-  const manifest = useManifest();
   const config = useConfig();
   const resource = useAppResource();
   const layoutActions = useLayoutActions();
@@ -126,27 +121,6 @@ function ExhibitionPresetPreviewButton({
     previewConfigs[0];
   const theseus = previewConfigs.find((item) => item.id === "theseus" || item.id === "theseus-viewer");
   const json = previewConfigs.find((item) => item.id === "raw-manifest");
-
-  useEffect(() => {
-    if (!manifest || !selectedTemplate) return;
-
-    const currentBehavior = (manifest.behavior as string[]) || [];
-    const resolvedTemplateBehaviors = templates.flatMap((template) => [template.type, `template-${template.id}`]);
-    const behavior = [
-      ...currentBehavior.filter(
-        (item) => !exhibitionTemplateBehaviors.includes(item) && !resolvedTemplateBehaviors.includes(item),
-      ),
-      selectedTemplate.type,
-      `template-${selectedTemplate.id}`,
-    ];
-    if (
-      behavior.length === currentBehavior.length &&
-      behavior.every((item, index) => item === currentBehavior[index])
-    ) {
-      return;
-    }
-    vault.modifyEntityField(manifest, "behavior", behavior);
-  }, [manifest, selectedTemplate, templates, vault]);
 
   async function openPreview(template: PresetTemplateDefinition) {
     const manifestId = await actions.getPreviewLink();

--- a/presets/exhibition-preset/src/index.tsx
+++ b/presets/exhibition-preset/src/index.tsx
@@ -18,18 +18,9 @@ import {
 } from "./creators/image-slide-creator";
 import { imageUrlSlideCreator } from "./creators/image-url-slide";
 import { exhibitionPresetConfig } from "./exhibition-onboarding";
-import {
-  infoBoxCreator,
-  slideshowLongEditorialCreator,
-} from "./creators/info-box-creator";
-import {
-  slideshowVideoCreator,
-  videoSlideCreator,
-} from "./creators/video-slide-creator";
-import {
-  slideshowYoutubeCreator,
-  youtubeSlideCreator,
-} from "./creators/youtube-slide-creator";
+import { infoBoxCreator, slideshowLongEditorialCreator } from "./creators/info-box-creator";
+import { slideshowVideoCreator, videoSlideCreator } from "./creators/video-slide-creator";
+import { slideshowYoutubeCreator, youtubeSlideCreator } from "./creators/youtube-slide-creator";
 import { exhibitionGridLeftPanel } from "./left-panels/ExhibitionGrid";
 import { exhibitionOverviewLeftPanel } from "./left-panels/ExhibitionOverview";
 import { exhibitionThemeLeftPanel } from "./left-panels/ExhibitionTheme";
@@ -42,12 +33,10 @@ import { infoBoxWorkbenchEditor } from "./right-panels/InfoBoxPanel";
 import { customBehaviourEditor } from "./right-panels/SlideBehaviours";
 
 export { default as PresetIcon } from "./icons/PresetIcon";
-export {
-  imageServiceSlideCreator,
-  type CreateImageServiceSlidePayload,
-} from "./creators/image-service-slide-creator";
+export { imageServiceSlideCreator, type CreateImageServiceSlidePayload } from "./creators/image-service-slide-creator";
 export { exhibitionEditorScrollingPreset } from "./presets/scrolling-preset";
 export { exhibitionEditorSlideshowPreset } from "./presets/slideshow-preset";
+export { useExhibitionPreviewWindow } from "./components/ExhibitionPreviewPanel";
 
 export const exhibitionEditorPreset = extendApp(
   mapApp(ManifestPreset, (app) => ({
@@ -130,5 +119,5 @@ export const exhibitionEditorPreset = extendApp(
       slideshowYoutubeCreator,
       slideshowLongEditorialCreator,
     ],
-  },
+  }
 );

--- a/presets/exhibition-preset/src/left-panels/ExhibitionGrid.tsx
+++ b/presets/exhibition-preset/src/left-panels/ExhibitionGrid.tsx
@@ -15,12 +15,12 @@ import {
   useEditingStack,
   useManifestEditor,
 } from "@manifest-editor/shell";
-import { useVault } from "react-iiif-vault";
 import { ExhibitionGrid } from "../components/ExhibitionGrid";
 import { ExhibitionPreviewList } from "../components/ExhibitionPreviewList";
 import { SortableExhibitionGrid } from "../components/SortableExhibitionGrid";
 import { useExhibitionTemplate } from "../helpers/exhibition-template";
 import { getSlideSelectionAfterDeletion } from "../helpers/slide-selection";
+import { getOpeningSplashCreatorInitialData } from "../right-panels/opening-splash";
 
 export const exhibitionGridLeftPanel = createExhibitionGridLeftPanel({
   label: "Exhibition grid",
@@ -67,7 +67,6 @@ function createExhibitionGridLeftPanel({
 function ExhibitionGridLeftPanel({ creatorFilter, previewMode }: { creatorFilter: string; previewMode: PreviewMode }) {
   const { structural, technical } = useManifestEditor();
   const selectedTemplate = useExhibitionTemplate();
-  const vault = useVault();
   const resolvedPreviewMode = resolvePreviewMode(previewMode, selectedTemplate?.type);
   const resolvedCreatorFilter = resolvedPreviewMode === "slideshow" ? "exhibition-slideshow-slide" : creatorFilter;
   const manifestId = technical.id.get();
@@ -78,8 +77,7 @@ function ExhibitionGridLeftPanel({ creatorFilter, previewMode }: { creatorFilter
   const selectedCanvasId = editingCanvas?.resource.source.id;
   const selectedIndex = selectedCanvasId ? items.findIndex((item) => item.id === selectedCanvasId) : -1;
   const insertIndex = selectedIndex >= 0 ? selectedIndex + 1 : undefined;
-  const scrollInitialData =
-    resolvedPreviewMode === "scroll" && !hasSplashCanvas(items, vault) ? { imageSlideBehavior: ["splash"] } : undefined;
+  const scrollInitialData = resolvedPreviewMode === "scroll" ? getOpeningSplashCreatorInitialData(items) : undefined;
   const [canCreateCanvas, canvasActions] = useCreator(
     manifest,
     "items",
@@ -160,13 +158,6 @@ function resolvePreviewMode(previewMode: PreviewMode, templateType?: string): Re
   if (previewMode !== "configured") return previewMode;
   if (templateType === "slideshow" || templateType === "scroll") return templateType;
   return "grid";
-}
-
-function hasSplashCanvas(items: Array<{ id: string }>, vault: ReturnType<typeof useVault>) {
-  return items.some((item) => {
-    const canvas = vault.get(item as any) as any;
-    return Array.isArray(canvas?.behavior) && canvas.behavior.includes("splash");
-  });
 }
 
 function ExhibitionGridIcon() {

--- a/presets/exhibition-preset/src/right-panels/ExhibitionCanvasEditor.tsx
+++ b/presets/exhibition-preset/src/right-panels/ExhibitionCanvasEditor.tsx
@@ -83,6 +83,7 @@ export function ExhibitionCanvasAdvancedContent() {
   const isAnExhibitionCanvas = isExhibitionItem(canvas);
   const isTextOnly = behavior.includes("info");
   const isOpeningCover = isOpeningSplashCanvas(canvas, manifestEditor.structural.items.get());
+  const isMisplacedSplash = behavior.includes("splash") && !isOpeningCover;
   const tourSupported = supportsTourSteps(vault, canvas);
   const hasTourSteps = useVaultSelector(
     (_, vaultInstance) => (canvas ? getTourStepAnnotations(vaultInstance, canvas).length > 0 : false),
@@ -99,7 +100,9 @@ export function ExhibitionCanvasAdvancedContent() {
   if (isTextOnly) {
     return (
       <ResourceEditingProvider resource={canvas}>
-        {!isAnExhibitionCanvas ? <ExhibitionItemConversion /> : null}
+        {!isAnExhibitionCanvas || isMisplacedSplash ? (
+          <ExhibitionItemConversion misplacedSplash={isMisplacedSplash} />
+        ) : null}
         <ReadonlyExhibitionSummary canvas={canvas} />
         {tourSupported ? <TourStepsSummary canvas={canvas} /> : null}
       </ResourceEditingProvider>
@@ -108,7 +111,9 @@ export function ExhibitionCanvasAdvancedContent() {
 
   return (
     <ResourceEditingProvider resource={canvas}>
-      {!isAnExhibitionCanvas ? <ExhibitionItemConversion /> : null}
+      {!isAnExhibitionCanvas || isMisplacedSplash ? (
+        <ExhibitionItemConversion misplacedSplash={isMisplacedSplash} />
+      ) : null}
 
       <RescaleSingleImagePrompt />
 

--- a/presets/exhibition-preset/src/right-panels/opening-splash.test.ts
+++ b/presets/exhibition-preset/src/right-panels/opening-splash.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, test } from "vitest";
-import { isOpeningSplashCanvas } from "./opening-splash";
+import { supportsTourSteps } from "../slideshow-content-positioning";
+import { getOpeningSplashCreatorInitialData, isOpeningSplashCanvas } from "./opening-splash";
 
 const items = [{ id: "canvas-1" }, { id: "canvas-2" }];
 
 describe("opening splash", () => {
+  test("only applies splash defaults while the exhibition is empty", () => {
+    expect(getOpeningSplashCreatorInitialData([])).toEqual({ imageSlideBehavior: ["splash"] });
+    expect(getOpeningSplashCreatorInitialData(items)).toBeUndefined();
+    expect(getOpeningSplashCreatorInitialData([{ id: "legacy-canvas-without-splash" }])).toBeUndefined();
+  });
+
   test("only the first splash canvas is the opening splash", () => {
     expect(
       isOpeningSplashCanvas({ id: "canvas-1", behavior: ["splash"] }, items),
@@ -23,4 +30,27 @@ describe("opening splash", () => {
     expect(isOpeningSplashCanvas(splash, items)).toBe(true);
     expect(isOpeningSplashCanvas(splash, [...items].reverse())).toBe(false);
   });
+
+  test("exposes Tour Steps only on normal image slides", () => {
+    const vault = { get: (resource: unknown) => resource };
+    const image = slide("canvas-2", ["image"], { id: "image", type: "Image" });
+    const splash = slide("canvas-1", ["splash"], { id: "image", type: "Image" });
+    const info = slide("canvas-2", ["info"], { id: "text", type: "TextualBody" });
+    const video = slide("canvas-2", ["image"], { id: "video", type: "Video" });
+    const exposesTourSteps = (canvas: ReturnType<typeof slide>) =>
+      supportsTourSteps(vault, canvas) && !isOpeningSplashCanvas(canvas, items);
+
+    expect(exposesTourSteps(image)).toBe(true);
+    expect(exposesTourSteps(splash)).toBe(false);
+    expect(exposesTourSteps(info)).toBe(false);
+    expect(exposesTourSteps(video)).toBe(false);
+  });
 });
+
+function slide(id: string, behavior: string[], body: { id: string; type: string }) {
+  return {
+    id,
+    behavior,
+    items: [{ items: [{ motivation: "painting", body }] }],
+  };
+}

--- a/presets/exhibition-preset/src/right-panels/opening-splash.ts
+++ b/presets/exhibition-preset/src/right-panels/opening-splash.ts
@@ -4,6 +4,10 @@ import type { EditableResource } from "@manifest-editor/shell";
 type CanvasLike = { id: string; behavior?: string[] | null };
 type ManifestItem = { id: string };
 
+export function getOpeningSplashCreatorInitialData(items: ManifestItem[]) {
+  return items.length === 0 ? { imageSlideBehavior: ["splash"] } : undefined;
+}
+
 export function isOpeningSplashCanvas(
   canvas: CanvasLike | null | undefined,
   items: ManifestItem[] | null | undefined,

--- a/presets/manifest-preset/package.json
+++ b/presets/manifest-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifest-editor/manifest-preset",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "bugs": "https://github.com/digirati-co-uk/iiif-manifest-editor/issues",
   "repository": {
@@ -67,8 +67,8 @@
     "zustand": "catalog:"
   },
   "devDependencies": {
-    "@tsdown/css": "catalog:",
     "@manifest-editor/ui": "workspace:*",
+    "@tsdown/css": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "tailwindcss": "^3.4.3",


### PR DESCRIPTION
## Summary
- prepare Manifest Editor 2.2.0 package updates
- fix scrolling exhibition splash and Tour Steps behaviour
- add exhibition preview and editor fixes

## Validation
- exhibition preset suite: 21 files, 109 tests

Created now to publish pkg.pr.new preview packages while portal integration continues.